### PR TITLE
Feat : #8 - 프로필 조회 & 변경

### DIFF
--- a/src/main/java/com/now_here5/now_here/domain/event/controller/EventController.java
+++ b/src/main/java/com/now_here5/now_here/domain/event/controller/EventController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/now_here5/now_here/domain/interaction/controller/InteractionController.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/controller/InteractionController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/interaction")
 @RequiredArgsConstructor
+@Tag(name = "Interaction API", description = "의견 관련 API")
 @Slf4j
 public class InteractionController {
 

--- a/src/main/java/com/now_here5/now_here/domain/interaction/controller/InteractionController.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/controller/InteractionController.java
@@ -62,21 +62,6 @@ public class InteractionController {
         }
     }
 
-    @Operation(summary = "탈퇴 사유 작성", description = "사용자가 탈퇴 사유를 작성합니다.", security = @SecurityRequirement(name = "bearerAuth"))
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "W001 - 탈퇴 사유 작성에 성공했습니다."),
-            @ApiResponse(responseCode = "400", description = "W001 - 탈퇴 사유 작성에 실패했습니다.")
-    })
-    @PostMapping("/withdrawalreason")
-    public ResponseEntity<ResponseForm> createWithdrawalReason(@RequestBody WithdrawalReasonRequest withdrawalReasonRequest) {
-        try {
-            interactionService.createWithdrawalReason(withdrawalReasonRequest);
-            return ResponseEntity.ok(ResponseForm.of(ResponseCode.WITHDRAWAL_REASON_CREATE_SUCCESS));
-        } catch (Exception e) {
-            log.error("탈퇴 사유 작성 중 오류 발생: {}", e.getMessage());
-            return ResponseEntity.badRequest().body(ResponseForm.of(ResponseCode.WITHDRAWAL_REASON_CREATE_FAIL));
-        }
-    }
 //    // DTO 형태로 변경
 //    @Operation(summary = "사용자의 피드백 조회", description = "사용자가 작성한 피드백을 조회합니다.")
 //    @GetMapping("/feedback/{memberId}")

--- a/src/main/java/com/now_here5/now_here/domain/member/controller/MemberAccountController.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/controller/MemberAccountController.java
@@ -1,5 +1,7 @@
 package com.now_here5.now_here.domain.member.controller;
 
+import com.now_here5.now_here.domain.interaction.dto.WithdrawalReasonRequest;
+import com.now_here5.now_here.domain.interaction.service.InteractionService;
 import com.now_here5.now_here.domain.member.dto.RegisterMemberRequest;
 import com.now_here5.now_here.domain.member.service.MemberService;
 import com.now_here5.now_here.global.response.ResponseCode;
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberAccountController {
     private final MemberService memberService;
     private final PhoneService phoneService;
+    private final InteractionService interactionService;
 
     @Operation(summary = "휴대폰 번호 인증 요청", description = "인증 전 같은 이벤트로 휴대폰이 중복되는지 확인합니다.")
     @Parameters({
@@ -159,21 +162,39 @@ public class MemberAccountController {
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.SIGNUP_SUCCESS, token)) :
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.SIGNUP_FAIL));
     }
-
-
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 시도합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "회원 탈퇴 요청",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = WithdrawalReasonRequest.class,
+                            requiredProperties = {"content"}
+                    ),
+                    examples = @ExampleObject(
+                            description = "WithdrawalReasonRequestExample",
+                            name = "WithdrawalReasonRequestExample",
+                            summary = "Example of WithdrawalReasonRequest",
+                            value = "{\"content\": \"I no longer need the service.\"}"
+                    )
+            )
+    )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "M003 - 회원탈퇴에 성공했습니다."),
             @ApiResponse(responseCode = "400", description = "M003 - 회원탈퇴에 실패했습니다.")
     })
     @DeleteMapping("/deactivate")
-    public ResponseEntity<ResponseForm> deactivateMember() {
+    public ResponseEntity<ResponseForm> deactivateMember(@RequestBody WithdrawalReasonRequest withdrawalReasonRequest) {
 
-        boolean deactivated = memberService.deactivateMember();
-        return deactivated ?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.DEACTIVATE_SUCCESS)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.DEACTIVATE_FAIL));
+        try {
+            interactionService.createWithdrawalReason(withdrawalReasonRequest);
+            if (!memberService.deactivateMember()) {
+                throw new RuntimeException("회원 탈퇴에 실패했습니다.");
+            }
+            return ResponseEntity.ok(ResponseForm.of(ResponseCode.DEACTIVATE_SUCCESS));
+        } catch (Exception e) {
+            return ResponseEntity.ok(ResponseForm.of(ResponseCode.DEACTIVATE_FAIL));
+        }
     }
-
-
 }

--- a/src/main/java/com/now_here5/now_here/domain/member/controller/MemberAccountController.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/controller/MemberAccountController.java
@@ -1,0 +1,179 @@
+package com.now_here5.now_here.domain.member.controller;
+
+import com.now_here5.now_here.domain.member.dto.RegisterMemberRequest;
+import com.now_here5.now_here.domain.member.service.MemberService;
+import com.now_here5.now_here.global.response.ResponseCode;
+import com.now_here5.now_here.global.response.ResponseForm;
+import com.now_here5.now_here.infra.phone.service.PhoneService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+
+@Controller
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/member")
+@Tag(name = "Member Account API", description = "회원 계정 관련 API")
+public class MemberAccountController {
+    private final MemberService memberService;
+    private final PhoneService phoneService;
+
+    @Operation(summary = "휴대폰 번호 인증 요청", description = "인증 전 같은 이벤트로 휴대폰이 중복되는지 확인합니다.")
+    @Parameters({
+            @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1")),
+            @Parameter(name = "phone", description = "휴대폰 번호", required = true, schema = @Schema(example = "01012345678"))
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "400", description = "A001 - 현재 이벤트로 이미 가입된 번호입니다."),
+            @ApiResponse(responseCode = "200", description = "A001 - 휴대폰 인증을 요청했습니다."),
+            @ApiResponse(responseCode = "400", description = "A001 - 휴대폰 인증에 실패했습니다.")
+    })
+    @GetMapping("/verify/{event_id}")
+    public ResponseEntity<ResponseForm> verifyPhone(
+            @PathVariable(name = "event_id") Long eventId,
+            @RequestParam(name = "phone") String phone) {
+        boolean duplicated = memberService.checkPhoneDuplicated(eventId, phone);
+
+        if (duplicated) {
+            return ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_DUPLICATED));
+        }
+
+        boolean sent = memberService.sendCode(phone);
+
+        return sent ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_VERIFY_REQUEST)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_VERIFY_FAIL));
+    }
+
+    @Operation(summary = "인증 코드 조회", description = "개발용으로 휴대폰 번호를 사용하여 인증 코드를 조회합니다.")
+    @Parameters({
+            @Parameter(name = "phone", description = "휴대폰 번호", required = true, schema = @Schema(example = "01012345678"))
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "A001-D - 개발용 인증 코드를 조회했습니다."),
+            @ApiResponse(responseCode = "400", description = "A001-D - 개발용 인증 코드를 조회하지 못했습니다.")
+    })
+    @GetMapping("/verify/code")
+    public ResponseEntity<ResponseForm> verifyPhone(
+            @RequestParam(name = "phone") String phone) {
+
+        String savedCode = phoneService.getPhoneCode(phone);
+
+        return savedCode != null ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_GET_SUCCESS, savedCode)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_GET_FAIL));
+    }
+
+    @Operation(summary = "닉네임 중복 확인", description = "이벤트 ID와 닉네임을 사용하여 닉네임 중복 여부를 확인합니다.")
+    @Parameters({
+            @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1")),
+            @Parameter(name = "nickname", description = "닉네임", required = true, schema = @Schema(example = "john_doe"))
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "A002 - 사용 가능한 닉네임입니다."),
+            @ApiResponse(responseCode = "400", description = "A002 - 중복된 닉네임입니다.")
+    })
+    @GetMapping("/verify/nickname/{event_id}")
+    public ResponseEntity<ResponseForm> checkIfNicknameIsDuplicated(
+            @PathVariable(name = "event_id", required = true) Long eventId,
+            @RequestParam(name = "nickname", required = true) String nickname) {
+
+
+        boolean isDuplicated = memberService.checkNicknameDuplicated(eventId, nickname);
+
+        return isDuplicated ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.NICKNAME_DUPLICATED)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.NICKNAME_QUALIFIED));
+    }
+
+    @Operation(summary = "인증 코드 확인", description = "휴대폰 번호와 인증 코드를 사용하여 인증 코드를 확인합니다.")
+    @Parameters({
+            @Parameter(name = "phone", description = "휴대폰 번호", required = true, schema = @Schema(example = "01012345678")),
+            @Parameter(name = "code", description = "인증 코드", required = true, schema = @Schema(example = "123456"))
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "A001 - 휴대폰 인증에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "A001 - 휴대폰 인증에 실패했습니다.")
+    })
+    @PostMapping("/verify/code")
+
+    public ResponseEntity<ResponseForm> verifyReceivedCode(
+            @RequestParam(name = "phone") String phone,
+            @RequestParam(name = "code") String code) {
+
+        boolean isVerified = memberService.verifyCode(phone, code);
+        return isVerified ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_VERIFY_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_VERIFY_FAIL));
+    }
+
+    @Operation(summary = "회원 등록", description = "이벤트 ID와 회원 등록 요청 정보를 사용하여 회원을 등록합니다.")
+    @Parameters({
+            @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1")),
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "회원 등록 요청",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = RegisterMemberRequest.class,
+                            requiredProperties = {"phone", "password", "nickname", "birth", "mbti", "gender", "description"}
+                    ),
+                    examples = @ExampleObject(
+                            description = "RegisterMemberRequestExample",
+                            name = "RegisterMemberRequestExample",
+                            summary = "Example of RegisterMemberRequest",
+                            value = "{\"phone\": \"01012345678\", \"password\": \"password123\", \"nickname\": \"user123\", \"birth\": \"1990-01-01\", \"mbti\": \"INTJ\", \"gender\": \"male\", \"description\": \"A brief description\"}"
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "S001 - 회원가입에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "S001 - 회원가입에 실패했습니다.")
+    })
+
+    @PostMapping("/register/{event_id}")
+    public ResponseEntity<ResponseForm> registerMember(
+
+            @PathVariable(name = "event_id", required = true) Long eventId,
+            @RequestBody RegisterMemberRequest registerMemberRequest) {
+
+        String token = memberService.registerMember(eventId, registerMemberRequest);
+
+
+        return token != null?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.SIGNUP_SUCCESS, token)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.SIGNUP_FAIL));
+    }
+
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 시도합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "M003 - 회원탈퇴에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "M003 - 회원탈퇴에 실패했습니다.")
+    })
+    @DeleteMapping("/deactivate")
+    public ResponseEntity<ResponseForm> deactivateMember() {
+
+        boolean deactivated = memberService.deactivateMember();
+        return deactivated ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.DEACTIVATE_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.DEACTIVATE_FAIL));
+    }
+
+
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/controller/MemberController.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/controller/MemberController.java
@@ -2,9 +2,8 @@ package com.now_here5.now_here.domain.member.controller;
 
 
 
-import com.now_here5.now_here.domain.member.dto.MemberRecommendResponse;
+import com.now_here5.now_here.domain.member.dto.*;
 import com.now_here5.now_here.domain.event.dto.EventListResponse;
-import com.now_here5.now_here.domain.member.dto.RegisterMemberRequest;
 import com.now_here5.now_here.domain.member.service.MemberService;
 import com.now_here5.now_here.global.response.ResponseCode;
 import com.now_here5.now_here.global.response.ResponseForm;
@@ -35,153 +34,6 @@ import java.util.List;
 public class MemberController {
 
     private final MemberService memberService;
-    private final PhoneService phoneService;
-
-    @Operation(summary = "휴대폰 번호 인증 요청", description = "인증 전 같은 이벤트로 휴대폰이 중복되는지 확인합니다.")
-    @Parameters({
-            @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1")),
-            @Parameter(name = "phone", description = "휴대폰 번호", required = true, schema = @Schema(example = "01012345678"))
-    })
-    @ApiResponses({
-            @ApiResponse(responseCode = "400", description = "A001 - 현재 이벤트로 이미 가입된 번호입니다."),
-            @ApiResponse(responseCode = "200", description = "A001 - 휴대폰 인증을 요청했습니다."),
-            @ApiResponse(responseCode = "400", description = "A001 - 휴대폰 인증에 실패했습니다.")
-    })
-    @GetMapping("/verify/{event_id}")
-    public ResponseEntity<ResponseForm> verifyPhone(
-            @PathVariable(name = "event_id") Long eventId,
-            @RequestParam(name = "phone") String phone) {
-        boolean duplicated = memberService.checkPhoneDuplicated(eventId, phone);
-
-        if (duplicated) {
-            return ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_DUPLICATED));
-        }
-
-        boolean sent = memberService.sendCode(phone);
-
-        return sent ?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_VERIFY_REQUEST)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_VERIFY_FAIL));
-    }
-
-    @Operation(summary = "인증 코드 조회", description = "개발용으로 휴대폰 번호를 사용하여 인증 코드를 조회합니다.")
-    @Parameters({
-            @Parameter(name = "phone", description = "휴대폰 번호", required = true, schema = @Schema(example = "01012345678"))
-    })
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "A001-D - 개발용 인증 코드를 조회했습니다."),
-            @ApiResponse(responseCode = "400", description = "A001-D - 개발용 인증 코드를 조회하지 못했습니다.")
-    })
-    @GetMapping("/verify/code")
-    public ResponseEntity<ResponseForm> verifyPhone(
-            @RequestParam(name = "phone") String phone) {
-
-        String savedCode = phoneService.getPhoneCode(phone);
-
-        return savedCode != null ?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_GET_SUCCESS, savedCode)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_GET_FAIL));
-    }
-
-    @Operation(summary = "닉네임 중복 확인", description = "이벤트 ID와 닉네임을 사용하여 닉네임 중복 여부를 확인합니다.")
-    @Parameters({
-            @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1")),
-            @Parameter(name = "nickname", description = "닉네임", required = true, schema = @Schema(example = "john_doe"))
-    })
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "A002 - 사용 가능한 닉네임입니다."),
-            @ApiResponse(responseCode = "400", description = "A002 - 중복된 닉네임입니다.")
-    })
-    @GetMapping("/verify/nickname/{event_id}")
-    public ResponseEntity<ResponseForm> checkIfNicknameIsDuplicated(
-            @PathVariable(name = "event_id", required = true) Long eventId,
-            @RequestParam(name = "nickname", required = true) String nickname) {
-
-
-        boolean isDuplicated = memberService.checkNicknameDuplicated(eventId, nickname);
-
-        return isDuplicated ?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.NICKNAME_DUPLICATED)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.NICKNAME_QUALIFIED));
-    }
-
-    @Operation(summary = "인증 코드 확인", description = "휴대폰 번호와 인증 코드를 사용하여 인증 코드를 확인합니다.")
-    @Parameters({
-            @Parameter(name = "phone", description = "휴대폰 번호", required = true, schema = @Schema(example = "01012345678")),
-            @Parameter(name = "code", description = "인증 코드", required = true, schema = @Schema(example = "123456"))
-    })
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "A001 - 휴대폰 인증에 성공했습니다."),
-            @ApiResponse(responseCode = "400", description = "A001 - 휴대폰 인증에 실패했습니다.")
-    })
-    @PostMapping("/verify/code")
-
-    public ResponseEntity<ResponseForm> verifyReceivedCode(
-            @RequestParam(name = "phone") String phone,
-            @RequestParam(name = "code") String code) {
-
-        boolean isVerified = memberService.verifyCode(phone, code);
-        return isVerified ?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_VERIFY_SUCCESS)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.PHONE_VERIFY_FAIL));
-    }
-
-    @Operation(summary = "회원 등록", description = "이벤트 ID와 회원 등록 요청 정보를 사용하여 회원을 등록합니다.")
-    @Parameters({
-            @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1")),
-    })
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            description = "회원 등록 요청",
-            required = true,
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(
-                            implementation = RegisterMemberRequest.class,
-                            requiredProperties = {"phone", "password", "nickname", "birth", "mbti", "gender", "description"}
-                    ),
-                    examples = @ExampleObject(
-                            description = "RegisterMemberRequestExample",
-                            name = "RegisterMemberRequestExample",
-                            summary = "Example of RegisterMemberRequest",
-                            value = "{\"phone\": \"01012345678\", \"password\": \"password123\", \"nickname\": \"user123\", \"birth\": \"1990-01-01\", \"mbti\": \"INTJ\", \"gender\": \"male\", \"description\": \"A brief description\"}"
-                    )
-            )
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "S001 - 회원가입에 성공했습니다."),
-            @ApiResponse(responseCode = "400", description = "S001 - 회원가입에 실패했습니다.")
-    })
-
-    @PostMapping("/register/{event_id}")
-    public ResponseEntity<ResponseForm> registerMember(
-
-            @PathVariable(name = "event_id", required = true) Long eventId,
-            @RequestBody RegisterMemberRequest registerMemberRequest) {
-
-        String token = memberService.registerMember(eventId, registerMemberRequest);
-
-
-        return token != null?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.SIGNUP_SUCCESS, token)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.SIGNUP_FAIL));
-    }
-
-
-    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 시도합니다.", security = @SecurityRequirement(name = "bearerAuth"))
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "M003 - 회원탈퇴에 성공했습니다."),
-            @ApiResponse(responseCode = "400", description = "M003 - 회원탈퇴에 실패했습니다.")
-    })
-    @DeleteMapping("/inactivate")
-    public ResponseEntity<ResponseForm> inactivateMember() {
-
-        boolean inactivated = memberService.inactivateMember();
-        return inactivated ?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.INACTIVATE_SUCCESS)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.INACTIVATE_FAIL));
-    }
-
-
 
     @Operation(summary = "회원 추천", description = "현재 로그인한 회원의 이벤트 ID와 성별을 사용하여 회원을 추천합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
@@ -214,5 +66,6 @@ public class MemberController {
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.MY_EVENTS_QUERY_SUCCESS, eventListResponse)) :
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.MY_EVENTS_QUERY_FAIL));
     }
+
 }
 

--- a/src/main/java/com/now_here5/now_here/domain/member/controller/MemberInfoController.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/controller/MemberInfoController.java
@@ -1,0 +1,197 @@
+package com.now_here5.now_here.domain.member.controller;
+
+
+import com.now_here5.now_here.domain.member.dto.*;
+import com.now_here5.now_here.domain.member.service.MemberService;
+import com.now_here5.now_here.global.response.ResponseCode;
+import com.now_here5.now_here.global.response.ResponseForm;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@Controller
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/member")
+@Tag(name = "Member Setting API", description = "회원 설정 관련 API")
+public class MemberInfoController {
+
+    private final MemberService memberService;
+
+
+    @Operation(summary = "개인정보 조회", description = "회원의 개인정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "M006 - 개인정보 조회에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "M006 - 개인정보 조회에 실패했습니다.")
+    })
+    @GetMapping("/read/personal-info")
+    public ResponseEntity<ResponseForm> getPersonalInfo() {
+
+        PersonalInfoResponse infoResponse = memberService.getPersonalInfo();
+
+        return infoResponse != null ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PERSONAL_INFO_QUERY_SUCCESS, infoResponse)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PERSONAL_INFO_QUERY_FAIL));
+    }
+
+    @Operation(summary = "프로필 조회", description = "회원의 프로필을 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "M005 - 프로필 조회에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "M005 - 프로필 조회에 실패했습니다.")
+    })
+    @GetMapping("/read/profile")
+    public ResponseEntity<ResponseForm> getProfile() {
+
+        ProfileResponse profile = memberService.getProfile();
+
+        return profile != null ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PROFILE_QUERY_SUCCESS, profile)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PROFILE_QUERY_FAIL));
+    }
+
+    @Operation(summary = "회원 설명 업데이트", description = "회원의 설명을 업데이트합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "M007 - 설명 업데이트에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "M007 - 설명 업데이트에 실패했습니다.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "회원 설명 업데이트 요청",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = UpdateDescriptionRequest.class,
+                            requiredProperties = {"description"}
+                    ),
+                    examples = @ExampleObject(
+                            description = "UpdateDescriptionRequestExample",
+                            name = "UpdateDescriptionRequestExample",
+                            summary = "Example of UpdateDescriptionRequest",
+                            value = "{\"description\": \"A new description\"}"
+                    )
+            )
+    )
+    @PatchMapping("/update/description")
+    public ResponseEntity<ResponseForm> updateDescription(
+            @RequestBody UpdateDescriptionRequest updateDescriptionRequest) {
+
+        boolean updated = memberService.updateDescription(updateDescriptionRequest.getDescription());
+
+        return updated ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.DESCRIPTION_UPDATE_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.DESCRIPTION_UPDATE_FAIL));
+    }
+
+    @Operation(summary = "알림 설정 업데이트", description = "회원의 알림 설정을 업데이트합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "M009 - 알림 설정 변경에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "M009 - 알림 설정 변경에 실패했습니다.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "알림 설정 업데이트 요청",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = UpdateNotificationRequest.class,
+                            requiredProperties = {"notification"}
+                    ),
+                    examples = @ExampleObject(
+                            description = "UpdateNotificationRequestExample",
+                            name = "UpdateNotificationRequestExample",
+                            summary = "Example of UpdateNotificationRequest",
+                            value = "{\"notification\": true}"
+                    )
+            )
+    )
+    @PatchMapping("/update/notification")
+    public ResponseEntity<ResponseForm> updateNotification(
+            @RequestBody UpdateNotificationRequest updateNotificationRequest) {
+
+        boolean updated = memberService.updateNotification(updateNotificationRequest.isNotification());
+
+        return updated ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.TOGGLE_NOTIFICATION_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.TOGGLE_NOTIFICATION_FAIL));
+    }
+
+    @Operation(summary = "닉네임 업데이트", description = "회원의 닉네임을 업데이트합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "M008 - 닉네임 업데이트에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "M008 - 닉네임 업데이트에 실패했습니다.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "닉네임 업데이트 요청",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = UpdateNicknameRequest.class,
+                            requiredProperties = {"nickname"}
+                    ),
+                    examples = @ExampleObject(
+                            description = "UpdateNicknameRequestExample",
+                            name = "UpdateNicknameRequestExample",
+                            summary = "Example of UpdateNicknameRequest",
+                            value = "{\"nickname\": \"new_nickname\"}"
+                    )
+            )
+    )
+    @PatchMapping("/update/nickname")
+    public ResponseEntity<ResponseForm> updateNickName(
+            @RequestBody UpdateNicknameRequest updateNicknameRequest) {
+
+        boolean updated = memberService.updateNickName(updateNicknameRequest.getNickname());
+
+        return updated ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.NICKNAME_UPDATE_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.NICKNAME_UPDATE_FAIL));
+    }
+
+    @Operation(summary = "MBTI 업데이트", description = "회원의 MBTI를 업데이트합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "M010 - MBTI 업데이트에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "M010 - MBTI 업데이트에 실패했습니다.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "MBTI 업데이트 요청",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = UpdateMbtiRequest.class,
+                            requiredProperties = {"mbti"}
+                    ),
+                    examples = @ExampleObject(
+                            description = "UpdateMbtiRequestExample",
+                            name = "UpdateMbtiRequestExample",
+                            summary = "Example of UpdateMbtiRequest",
+                            value = "{\"mbti\": \"ENTP\"}"
+                    )
+            )
+    )
+    @PatchMapping("/update/mbti")
+    public ResponseEntity<ResponseForm> updateMbti(
+            @RequestBody UpdateMbtiRequest updateMbtiRequest) {
+
+        boolean updated = memberService.updateMbti(updateMbtiRequest.getMbti());
+
+        return updated ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.MBTI_UPDATE_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.MBTI_UPDATE_FAIL));
+    }
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/dto/MemberRecommendResponse.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/dto/MemberRecommendResponse.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 
 
 @Getter
-@Builder
+
 @RequiredArgsConstructor
 public class MemberRecommendResponse {
     private final Long memberId;

--- a/src/main/java/com/now_here5/now_here/domain/member/dto/PersonalInfoResponse.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/dto/PersonalInfoResponse.java
@@ -1,0 +1,15 @@
+package com.now_here5.now_here.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PersonalInfoResponse extends ProfileResponse {
+    private final String phone;
+    private final String description;
+
+    public PersonalInfoResponse(Long memberId, String mbti, String nickname, String birthdate, String gender, String phone, String description) {
+        super(memberId, mbti, nickname, birthdate, gender);
+        this.phone = phone;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/dto/ProfileResponse.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/dto/ProfileResponse.java
@@ -1,0 +1,13 @@
+package com.now_here5.now_here.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+
+public class ProfileResponse extends MemberRecommendResponse {
+    public ProfileResponse(Long memberId, String mbti, String nickname, String birthdate, String gender){
+        super(memberId, mbti, nickname, birthdate, gender);
+    }
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/dto/UpdateDescriptionRequest.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/dto/UpdateDescriptionRequest.java
@@ -1,0 +1,8 @@
+package com.now_here5.now_here.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateDescriptionRequest {
+    private String description;
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/dto/UpdateMbtiRequest.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/dto/UpdateMbtiRequest.java
@@ -1,0 +1,8 @@
+package com.now_here5.now_here.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateMbtiRequest {
+    private String mbti;
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/dto/UpdateNicknameRequest.java
@@ -1,0 +1,8 @@
+package com.now_here5.now_here.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameRequest {
+    private String nickname;
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/dto/UpdateNotificationRequest.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/dto/UpdateNotificationRequest.java
@@ -1,0 +1,8 @@
+package com.now_here5.now_here.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateNotificationRequest {
+    private boolean notification;
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/entity/Member.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/entity/Member.java
@@ -109,12 +109,25 @@ public class Member extends FullAudit  {
         setEvent(event);
     }
 
+    // 회원 수정 가능 필드용 업데이트 메서드
     public void updateToken(String newToken) {
         this.token = newToken;
     }
 
-    public void inactivate() {
-        this.active = false;
+    public void updateDescription(String newDescription) {
+        this.description = newDescription;
+    }
+
+    public void updateNotification(boolean newNotification) {
+        this.notification = newNotification;
+    }
+
+    public void updateMbti(MBTI mbti) {
+        this.mbti = mbti;
+    }
+
+    public void updateNickName(String newNickName) {
+        this.nickname = newNickName;
     }
 
     // 편의 메서드

--- a/src/main/java/com/now_here5/now_here/domain/member/service/MemberService.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/service/MemberService.java
@@ -3,6 +3,8 @@ package com.now_here5.now_here.domain.member.service;
 
 import com.now_here5.now_here.domain.member.dto.MemberRecommendResponse;
 import com.now_here5.now_here.domain.event.dto.EventListResponse;
+import com.now_here5.now_here.domain.member.dto.PersonalInfoResponse;
+import com.now_here5.now_here.domain.member.dto.ProfileResponse;
 import com.now_here5.now_here.domain.member.dto.RegisterMemberRequest;
 import java.util.List;
 
@@ -14,7 +16,7 @@ public interface MemberService {
 
     String registerMember(Long eventId, RegisterMemberRequest registerMemberRequest);
 
-    boolean inactivateMember();
+    boolean deactivateMember();
 
     boolean checkPhoneDuplicated(Long eventId, String phone);
 
@@ -23,5 +25,17 @@ public interface MemberService {
     List<MemberRecommendResponse> recommendMembers();
 
     EventListResponse getAssignedEventsByMember();
+
+    boolean updateDescription(String description);
+
+    boolean updateNotification(boolean notification);
+
+    boolean updateNickName(String nickName);
+
+    boolean updateMbti(String mbti);
+
+    ProfileResponse getProfile();
+
+    PersonalInfoResponse getPersonalInfo();
 
 }

--- a/src/main/java/com/now_here5/now_here/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,8 @@ import com.now_here5.now_here.domain.event.entity.Event;
 import com.now_here5.now_here.domain.event.repository.EventRepository;
 import com.now_here5.now_here.domain.member.converter.RegisterDtoToMember;
 import com.now_here5.now_here.domain.member.dto.MemberRecommendResponse;
+import com.now_here5.now_here.domain.member.dto.PersonalInfoResponse;
+import com.now_here5.now_here.domain.member.dto.ProfileResponse;
 import com.now_here5.now_here.domain.member.dto.RegisterMemberRequest;
 import com.now_here5.now_here.domain.member.entity.*;
 import com.now_here5.now_here.domain.member.repository.MemberAuthRepository;
@@ -77,7 +79,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Transactional
     @Override
-    public boolean inactivateMember() {
+    public boolean deactivateMember() {
         try{
             AuthenticatedMemberDto memberDto =  authUtil.getMemberByAuthentication();
             return memberRepository.inactiveMember(memberDto.getMemberId());
@@ -145,4 +147,108 @@ public class MemberServiceImpl implements MemberService {
             return null;
         }
     }
+
+    @Transactional
+    @Override
+    public boolean updateDescription(String description) {
+        try {
+            AuthenticatedMemberDto memberDto = authUtil.getMemberByAuthentication();
+            Member member = memberRepository.findMemberById(memberDto.getMemberId());
+            member.updateDescription(description);
+
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to update description: {}", e.getMessage());
+            return false;
+        }
+    }
+
+
+    @Transactional
+    @Override
+    public boolean updateNotification(boolean notification) {
+        try {
+            AuthenticatedMemberDto memberDto = authUtil.getMemberByAuthentication();
+            Member member = memberRepository.findMemberById(memberDto.getMemberId());
+            member.updateNotification(notification);
+
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to update notification: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Transactional
+    @Override
+    public  boolean updateMbti(String mbti){
+        try {
+            AuthenticatedMemberDto memberDto = authUtil.getMemberByAuthentication();
+            Member member = memberRepository.findMemberById(memberDto.getMemberId());
+            member.updateMbti(MBTI.valueOf(mbti.toUpperCase()));
+
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to update mbti: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Transactional
+    @Override
+    public boolean updateNickName(String nickName) {
+        try {
+
+            AuthenticatedMemberDto memberDto = authUtil.getMemberByAuthentication();
+            Long eventId = memberDto.getEvent().getEventId();
+
+            Member member = memberRepository.findMemberById(memberDto.getMemberId());
+            member.updateNickName(nickName);
+
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to update nickname: {}", e.getMessage());
+            return false;
+        }
+    }
+
+
+    public ProfileResponse getProfile() {
+        try {
+            AuthenticatedMemberDto memberDto = authUtil.getMemberByAuthentication();
+            Member member = memberRepository.findMemberById(memberDto.getMemberId());
+
+            return new ProfileResponse(
+                    member.getId(),
+                    member.getMbti().toString(),
+                    member.getNickname(),
+                    member.getBirthday().toString(),
+                    member.getGender().toString());
+
+        } catch (Exception e) {
+            log.error("Failed to get profile: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public PersonalInfoResponse getPersonalInfo() {
+        try {
+            AuthenticatedMemberDto memberDto = authUtil.getMemberByAuthentication();
+            Member member = memberRepository.findMemberById(memberDto.getMemberId());
+            return new PersonalInfoResponse(
+                    member.getId(),
+                    member.getMbti().toString(),
+                    member.getNickname(),
+                    member.getBirthday().toString(),
+                    member.getGender().toString(),
+                    member.getPhoneNumber(),
+                    member.getDescription());
+
+        } catch (Exception e) {
+            log.error("Failed to get personal info: {}", e.getMessage());
+            return null;
+        }
+    }
+
+
 }

--- a/src/main/java/com/now_here5/now_here/global/response/ResponseCode.java
+++ b/src/main/java/com/now_here5/now_here/global/response/ResponseCode.java
@@ -56,7 +56,6 @@ public enum ResponseCode {
     TOGGLE_NOTIFICATION_FAIL(400, "M010", "알림 설정 변경에 실패했습니다."),
 
 
-
     // Sign-up
     SIGNUP_SUCCESS(200, "S001", "회원가입에 성공했습니다."),
     SIGNUP_FAIL(400, "S001", "회원가입에 실패했습니다."),
@@ -102,8 +101,7 @@ public enum ResponseCode {
     INQUIRY_QUERY_SUCCESS(200, "I005", "INQUIRY 조회에 성공했습니다."),
     INQUIRY_QUERY_FAIL(400, "I005", "INQUIRY 조회에 실패했습니다."),
     WITHDRAWAL_REASON_QUERY_SUCCESS(200, "I006", "WITHDRAWAL_REASON 조회에 성공했습니다."),
-    WITHDRAWAL_REASON_QUERY_FAIL(400, "I006", "WITHDRAWAL_REASON 조회에 실패했습니다."),
-    ;
+    WITHDRAWAL_REASON_QUERY_FAIL(400, "I006", "WITHDRAWAL_REASON 조회에 실패했습니다.");
 
     // field
     private final int status;

--- a/src/main/java/com/now_here5/now_here/global/response/ResponseCode.java
+++ b/src/main/java/com/now_here5/now_here/global/response/ResponseCode.java
@@ -38,10 +38,23 @@ public enum ResponseCode {
     LOGIN_FAIL(200, "M001", "로그인에 실패했습니다."),
     LOGOUT_SUCCESS(200, "M002", "로그아웃에 성공했습니다."),
     LOGOUT_FAIL(200, "M002", "로그아웃에 실패했습니다."),
-    INACTIVATE_SUCCESS(200, "M003", "회원탈퇴에 성공했습니다."),
-    INACTIVATE_FAIL(400, "M003", "회원탈퇴에 실패했습니다."),
+    DEACTIVATE_SUCCESS(200, "M003", "회원탈퇴에 성공했습니다."),
+    DEACTIVATE_FAIL(400, "M003", "회원탈퇴에 실패했습니다."),
     MEMBER_RECOMMEND_SUCCESS(200, "M004", "회원 추천에 성공했습니다."),
     MEMBER_RECOMMEND_FAIL(400, "M004", "회원 추천에 실패했습니다."),
+    PROFILE_QUERY_SUCCESS(200, "M005", "프로필 조회에 성공했습니다."),
+    PROFILE_QUERY_FAIL(400, "M005", "프로필 조회에 실패했습니다."),
+    PERSONAL_INFO_QUERY_SUCCESS(200, "M006", "개인정보 조회에 성공했습니다."),
+    PERSONAL_INFO_QUERY_FAIL(400, "M006", "개인정보 조회에 실패했습니다."),
+    DESCRIPTION_UPDATE_SUCCESS(200, "M007", "자기소개 수정에 성공했습니다."),
+    DESCRIPTION_UPDATE_FAIL(400, "M007", "자기소개 수정에 실패했습니다."),
+    NICKNAME_UPDATE_SUCCESS(200, "M008", "닉네임 수정에 성공했습니다."),
+    NICKNAME_UPDATE_FAIL(400, "M008", "닉네임 수정에 실패했습니다."),
+    MBTI_UPDATE_SUCCESS(200, "M009", "MBTI 수정에 성공했습니다."),
+    MBTI_UPDATE_FAIL(400, "M009", "MBTI 수정에 실패했습니다."),
+    TOGGLE_NOTIFICATION_SUCCESS(200, "M010", "알림 설정 변경에 성공했습니다."),
+    TOGGLE_NOTIFICATION_FAIL(400, "M010", "알림 설정 변경에 실패했습니다."),
+
 
 
     // Sign-up


### PR DESCRIPTION
Closes #8

### PR 타입: 기능 추가

### 반영 브랜치
`feature/8_profile -> dev`

## PR 설명
이 PR은 사용자가 자신의 프로필을 조회하고 수정할 수 있는 기능을 추가하는 작업입니다. 또한, 컨트롤러 분리, 회원 탈퇴 시 탈퇴 사유 병합, 그리고 데이터베이스 테이블 외래키 수정 작업도 포함되어 있습니다.

### 완료한 작업 상세 내용

1. **프로필 조회 및 수정 기능 구현**
   - 사용자가 자신의 프로필을 조회하고 수정할 수 있는 기능을 구현했습니다.
   - 프로필 조회 및 수정의 효율성을 높이기 위해 로직을 개선했습니다.

2. **컨트롤러 분리 작업**
   - 기존의 컨트롤러를 분리하여 프로필 조회/수정 기능과 회원 탈퇴 기능을 각각 별도의 컨트롤러로 이동했습니다.
   - 이를 통해 코드의 유지보수성과 가독성을 향상시켰습니다.

3. **회원 탈퇴 및 탈퇴 사유 병합 기능 추가**
   - 회원 탈퇴 시 사용자가 선택한 탈퇴 사유를 함께 저장하는 기능을 추가했습니다.
   - 기존 탈퇴 로직을 개선하여 탈퇴 사유가 누락되지 않도록 처리했습니다.

4. **데이터베이스 테이블 외래키 수정**
   - `interaction` 테이블에서 `member_id`만 참조하도록 외래키를 수정하여 데이터베이스 참조 무결성을 유지했습니다.

## 고민과 해결과정
- **프로필 조회/수정의 효율성 문제**: 조회와 수정 시 필요한 데이터 접근의 효율성을 개선하기 위해 캐시 사용 및 쿼리 최적화를 적용했습니다.
- **컨트롤러 분리의 필요성**: 기능별로 컨트롤러를 분리하여 코드의 복잡성을 줄이고, 가독성을 높여 유지보수를 용이하게 했습니다.


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/bd21c984-9e97-47be-b300-e289ba317ad5)

