### PR TITLE
Feat : #10 - 관리자용 Slack 기능 추가  (문의사항, 알림테스트)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
       - name: Connect deploy key
         uses: cloudtype-github-actions/connect@v1
         with:
@@ -62,6 +62,10 @@ jobs:
                   value: ${{ secrets.CT_DB_PASSWORD }}
                 - name: XOR_KEY
                   value: ${{ secrets.XOR_KEY }}
+                - name: SLACK_WEBHOOK_URL
+                  value: ${{ secrets.SLACK_WEBHOOK_URL }}
+                - name: SLACK_INQUIRY_WEBHOOK_URL
+                  value: ${{ secrets.SLACK_INQUIRY_WEBHOOK_URL }}
               start: java -Duser.timezone=Asia/Seoul -jar ./build/libs/now_here-0.0.1-SNAPSHOT.jar
               buildenv: []
             context:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -76,12 +76,16 @@ jobs:
             sudo docker stop now-here-server || true
             sudo docker rm now-here-server || true
             if ! sudo docker run -d --name now-here-server -p 8080:8080 \
+            
               -e DB_HOST=${{ secrets.OC_DB_PV_HOST }} \
               -e DB_PORT=${{ secrets.OC_DB_PORT }} \
               -e DB_NAME=${{ secrets.OC_DB_NAME }} \
               -e DB_USERNAME=${{ secrets.OC_DB_USERNAME }} \
               -e DB_PASSWORD=${{ secrets.OC_DB_PASSWORD }} \
               -e XOR_KEY=${{ secrets.XOR_KEY }} \
+              -e SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }} \
+              -e SLACK_INQUIRY_WEBHOOK_URL=${{ secrets.SLACK_INQUIRY_WEBHOOK_URL }} \
+    
               ${{ secrets.OCIR_REPOSITORY_URL }}:latest; then
               echo "Failed to run Docker container"
               exit 1

--- a/src/main/java/com/now_here5/now_here/domain/interaction/dto/InquiryRequest.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/dto/InquiryRequest.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @Builder
 public class InquiryRequest {
     private String content;
-    private boolean answered;
+    private String phoneNumber;
 }

--- a/src/main/java/com/now_here5/now_here/domain/interaction/dto/InquiryResponse.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/dto/InquiryResponse.java
@@ -1,0 +1,13 @@
+package com.now_here5.now_here.domain.interaction.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class InquiryResponse {
+    private final Long inquiryId;
+    private final String answer;
+    private final String inquiryContent;
+}

--- a/src/main/java/com/now_here5/now_here/domain/interaction/entity/Inquiry.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/entity/Inquiry.java
@@ -21,4 +21,9 @@ public class Inquiry extends Interaction{
         super(content, member);
         this.answered = answered;
     }
+
+
+//    void updateAnswer(String answer) {
+//        this.content = answer;
+//    }
 }

--- a/src/main/java/com/now_here5/now_here/domain/interaction/entity/Inquiry.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/entity/Inquiry.java
@@ -11,19 +11,23 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "inquiry")
-public class Inquiry extends Interaction{
+public class Inquiry extends Interaction {
 
-    @Column(name = "answered", nullable = false)
-    private boolean answered;
+    @Column(name = "phone_number", nullable = true)
+    private String phoneNumber;
+
+    @Column(name = "answer", nullable = true)
+    private String answer;
 
     @Builder
-    public Inquiry(String content, Member member, boolean answered) {
+    public Inquiry(String content, Member member, String phoneNumber, String answer) {
         super(content, member);
-        this.answered = answered;
+        this.phoneNumber = phoneNumber;
+        this.answer = answer;
     }
 
-
-//    void updateAnswer(String answer) {
-//        this.content = answer;
-//    }
+    // 답변을 업데이트하는 메서드
+    public void updateAnswer(String answer) {
+        this.answer = answer;
+    }
 }

--- a/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionService.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionService.java
@@ -22,4 +22,7 @@ public interface InteractionService {
     List<Inquiry> getInquiriesByMemberId(Long memberId);
 
     List<WithdrawalReason> getWithdrawalReasonsByMemberId(Long memberId);
+
+    void processInquiryResponse(Long inquiryId, String answer);
+
 }

--- a/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionServiceImpl.java
@@ -2,6 +2,7 @@ package com.now_here5.now_here.domain.interaction.service;
 
 import com.now_here5.now_here.domain.interaction.dto.FeedbackRequect;
 import com.now_here5.now_here.domain.interaction.dto.InquiryRequest;
+import com.now_here5.now_here.domain.interaction.dto.InquiryResponse;
 import com.now_here5.now_here.domain.interaction.dto.WithdrawalReasonRequest;
 import com.now_here5.now_here.domain.interaction.entity.Feedback;
 import com.now_here5.now_here.domain.interaction.entity.Inquiry;
@@ -11,6 +12,8 @@ import com.now_here5.now_here.domain.member.entity.Member;
 import com.now_here5.now_here.domain.member.repository.MemberRepository;
 import com.now_here5.now_here.global.security.dto.AuthenticatedMemberDto;
 import com.now_here5.now_here.global.util.AuthUtil;
+import com.now_here5.now_here.infra.phone.service.PhoneService;
+import com.now_here5.now_here.infra.slack.service.SlackInquiryHandlerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -24,6 +27,8 @@ public class InteractionServiceImpl implements InteractionService {
     private final InteractionRepository interactionRepository;
     private final MemberRepository memberRepository;
     private final AuthUtil authUtil;
+    private final SlackInquiryHandlerService slackInquiryHandlerService;
+    private final PhoneService phoneService;
 
     @Override
     public void createFeedback(FeedbackRequect feedbackRequect) {
@@ -46,7 +51,32 @@ public class InteractionServiceImpl implements InteractionService {
                 .member(member)
                 .answered(inquiryRequest.isAnswered())
                 .build();
+
         interactionRepository.saveInquiry(inquiry);
+        slackInquiryHandlerService.sendSlackNotification(inquiry.getId(), inquiry.getContent(), "01022223333");
+    }
+
+    @Override
+    public void processInquiryResponse(Long inquiryId, String answer) {
+        Inquiry foundInquiry = interactionRepository.findInquiryById(inquiryId);
+
+        if (foundInquiry!=null) {
+           // foundInquiry.setAnswered(true); // 답변 완료 처리 필드 대신 답변 내용이 채워져 있는지로 구분 가능할듯.
+           //  foundInquiry.setAnswer(answer); 나중에는 이것만 사용.
+
+            String responseMessage = String.format("[Now, Here] 질문에 대한 답변: %s", answer);
+            InquiryResponse inquiryResponse = InquiryResponse.builder()
+                    .inquiryId(inquiryId)
+                    .answer(responseMessage)
+                    .inquiryContent(foundInquiry.getContent())
+                    .build();
+
+            // SMS 전송
+//            phoneService.sendSms(foundInquiry.getPhoneNubmer(), responseMessage); 나중에 이거 이용.
+              phoneService.sendSms("01022223333", inquiryResponse);
+        } else {
+            System.out.println("Inquiry not found for ID: " + inquiryId);
+        }
     }
 
     @Override

--- a/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionServiceImpl.java
@@ -15,13 +15,16 @@ import com.now_here5.now_here.global.util.AuthUtil;
 import com.now_here5.now_here.infra.phone.service.PhoneService;
 import com.now_here5.now_here.infra.slack.service.SlackInquiryHandlerService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class InteractionServiceImpl implements InteractionService {
 
     private final InteractionRepository interactionRepository;
@@ -30,6 +33,7 @@ public class InteractionServiceImpl implements InteractionService {
     private final SlackInquiryHandlerService slackInquiryHandlerService;
     private final PhoneService phoneService;
 
+    @Transactional
     @Override
     public void createFeedback(FeedbackRequect feedbackRequect) {
         Long memberId = authUtil.getMemberByAuthentication().getMemberId();
@@ -42,27 +46,33 @@ public class InteractionServiceImpl implements InteractionService {
         interactionRepository.saveFeedback(feedback);
     }
 
+    @Transactional
     @Override
     public void createInquiry(InquiryRequest inquiryRequest) {
         Long memberId = authUtil.getMemberByAuthentication().getMemberId();
-        Member member = memberRepository.findActiveMemberById(memberId);
-        Inquiry inquiry = Inquiry.builder()
-                .content(inquiryRequest.getContent())
-                .member(member)
-                .answered(inquiryRequest.isAnswered())
-                .build();
+        Inquiry.InquiryBuilder builder = Inquiry.builder();
+        builder.content(inquiryRequest.getContent());
 
-        interactionRepository.saveInquiry(inquiry);
-        slackInquiryHandlerService.sendSlackNotification(inquiry.getId(), inquiry.getContent(), "01022223333");
+        builder.phoneNumber(inquiryRequest.getPhoneNumber());
+        if(memberId == null) {
+            log.warn("Member ID is null");
+        }else{
+            builder.member(memberRepository.findActiveMemberById(memberId));
+        }
+
+        Inquiry newInquiry = builder.build();
+        interactionRepository.saveInquiry(newInquiry);
+        slackInquiryHandlerService.sendSlackNotification(newInquiry.getId(), newInquiry.getContent(), newInquiry.getPhoneNumber());
     }
 
+    @Transactional
     @Override
     public void processInquiryResponse(Long inquiryId, String answer) {
         Inquiry foundInquiry = interactionRepository.findInquiryById(inquiryId);
 
         if (foundInquiry!=null) {
-           // foundInquiry.setAnswered(true); // 답변 완료 처리 필드 대신 답변 내용이 채워져 있는지로 구분 가능할듯.
-           //  foundInquiry.setAnswer(answer); 나중에는 이것만 사용.
+
+            foundInquiry.updateAnswer(answer);
 
             String responseMessage = String.format("[Now, Here] 질문에 대한 답변: %s", answer);
             InquiryResponse inquiryResponse = InquiryResponse.builder()
@@ -72,13 +82,13 @@ public class InteractionServiceImpl implements InteractionService {
                     .build();
 
             // SMS 전송
-//            phoneService.sendSms(foundInquiry.getPhoneNubmer(), responseMessage); 나중에 이거 이용.
-              phoneService.sendSms("01022223333", inquiryResponse);
+            phoneService.sendSms(foundInquiry.getPhoneNumber(), responseMessage);
         } else {
             System.out.println("Inquiry not found for ID: " + inquiryId);
         }
     }
 
+    @Transactional
     @Override
     public void createWithdrawalReason(WithdrawalReasonRequest withdrawalReasonRequest) {
         Long memberId = authUtil.getMemberByAuthentication().getMemberId();

--- a/src/main/java/com/now_here5/now_here/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/service/MemberServiceImpl.java
@@ -33,14 +33,13 @@ public class MemberServiceImpl implements MemberService {
     private final RegisterDtoToMember registerDtoToMember;
     private final EventRepository eventRepository;
     private final AuthUtil authUtil;
-    private final MemberAuthRepository memberAuthRepository;
     private final EventListToDto eventListToDto;
 
 
     @Override
     public boolean sendCode(String phone) {
         try{
-            return  phoneService.sendVerificationCode(phone);
+            return phoneService.sendVerificationCode(phone);
         } catch (Exception e) {
             log.error("Failed to send verification code to phone number: {}", phone);
             return false;

--- a/src/main/java/com/now_here5/now_here/global/config/RestConfig.java
+++ b/src/main/java/com/now_here5/now_here/global/config/RestConfig.java
@@ -1,0 +1,14 @@
+package com.now_here5.now_here.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/now_here5/now_here/global/config/SecurityConfig.java
+++ b/src/main/java/com/now_here5/now_here/global/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                                 // 매니저 대상
                                 .requestMatchers("/swagger-ui/**").permitAll()
                                 .requestMatchers("/v3/api-docs/**").permitAll()
-
+                                .requestMatchers("/slack/**").permitAll()
                                 // 비유저 대상
                                 .requestMatchers(HttpMethod.GET, "*/verify/**").permitAll()
                                 .requestMatchers(HttpMethod.POST, "*/verify/**").permitAll()

--- a/src/main/java/com/now_here5/now_here/infra/phone/service/NaverPhoneServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/infra/phone/service/NaverPhoneServiceImpl.java
@@ -1,6 +1,8 @@
 package com.now_here5.now_here.infra.phone.service;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.now_here5.now_here.global.util.RandomNumberUntil;
 import com.now_here5.now_here.infra.phone.repository.MemoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +17,6 @@ public class NaverPhoneServiceImpl implements PhoneService {
 
     @Override
     public boolean sendVerificationCode(String phone) {
-
         try{
             String randomCode= RandomNumberUntil.generateRandomCode();
             log.info("Send verification code to phone number: {}, code : {}", phone, randomCode);
@@ -25,7 +26,6 @@ public class NaverPhoneServiceImpl implements PhoneService {
         }catch(Exception e){
             return false;
         }
-
     }
 
     @Override
@@ -65,4 +65,22 @@ public class NaverPhoneServiceImpl implements PhoneService {
         }
 
     }
+
+    @Override
+    public void sendSms(String phone, Object dto) {
+
+        try {
+            // dto를 JSON 문자열로 변환
+            String jsonMessage = new ObjectMapper().writeValueAsString(dto);
+            log.info("Send SMS to phone number: {}, message: {}", phone, jsonMessage);
+
+            // 예: naverSmsApi.send(phone, jsonMessage);
+
+        } catch (JsonProcessingException e) {
+            log.error("Failed to convert dto to JSON: {}", dto, e);
+        }
+        log.info("Send SMS to phone number: {}, message : {}", phone, dto);
+
+    }
+
 }

--- a/src/main/java/com/now_here5/now_here/infra/phone/service/PhoneService.java
+++ b/src/main/java/com/now_here5/now_here/infra/phone/service/PhoneService.java
@@ -9,4 +9,6 @@ public interface PhoneService {
     boolean isVerifiedPhone( String phone) ;
 
     String getPhoneCode(String phone);
+
+    void sendSms(String phone, Object message);
 }

--- a/src/main/java/com/now_here5/now_here/infra/slack/controller/SlackEventController.java
+++ b/src/main/java/com/now_here5/now_here/infra/slack/controller/SlackEventController.java
@@ -1,9 +1,11 @@
 package com.now_here5.now_here.infra.slack.controller;
 
-import com.now_here5.now_here.domain.interaction.service.InteractionService;
 import com.now_here5.now_here.infra.slack.service.SlackEventService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,12 +22,23 @@ public class SlackEventController {
     private final SlackEventService slackEventService;
 
     @PostMapping("/handle-inquiry")
-    public String handleSlackEvent(@RequestBody Map<String, Object> payload) {
+    public ResponseEntity<String> handleSlackEvent(@RequestBody Map<String, Object> payload) {
         try {
-            return slackEventService.processSlackEvent(payload);
+            // Slack의 URL verification 요청을 처리
+            if ("url_verification".equals(payload.get("type"))) {
+                String challenge = (String) payload.get("challenge");
+                return ResponseEntity.ok()
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .body(challenge);
+            }
+
+            // 다른 이벤트 처리 로직
+            return ResponseEntity.ok(slackEventService.processSlackEvent(payload));
+
         } catch (Exception e) {
             log.error("An unexpected error occurred while handling Slack event.", e);
-            return "Error: An unexpected error occurred.";
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Error: An unexpected error occurred.");
         }
     }
 }

--- a/src/main/java/com/now_here5/now_here/infra/slack/controller/SlackEventController.java
+++ b/src/main/java/com/now_here5/now_here/infra/slack/controller/SlackEventController.java
@@ -1,0 +1,31 @@
+package com.now_here5.now_here.infra.slack.controller;
+
+import com.now_here5.now_here.domain.interaction.service.InteractionService;
+import com.now_here5.now_here.infra.slack.service.SlackEventService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/slack/event")
+@RequiredArgsConstructor
+@Slf4j
+public class SlackEventController {
+
+    private final SlackEventService slackEventService;
+
+    @PostMapping("/handle-inquiry")
+    public String handleSlackEvent(@RequestBody Map<String, Object> payload) {
+        try {
+            return slackEventService.processSlackEvent(payload);
+        } catch (Exception e) {
+            log.error("An unexpected error occurred while handling Slack event.", e);
+            return "Error: An unexpected error occurred.";
+        }
+    }
+}

--- a/src/main/java/com/now_here5/now_here/infra/slack/service/SlackEventService.java
+++ b/src/main/java/com/now_here5/now_here/infra/slack/service/SlackEventService.java
@@ -1,0 +1,99 @@
+package com.now_here5.now_here.infra.slack.service;
+
+import com.now_here5.now_here.domain.interaction.service.InteractionService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SlackEventService {
+
+    private final InteractionService interactionService;
+
+    public String processSlackEvent(Map<String, Object> payload) {
+        EventDetails eventDetails = parseEventDetails(payload);
+
+        if (eventDetails != null && "app_mention".equals(eventDetails.getType())) {
+            log.info("Received a mention from user {} in channel {}, text : {}",
+                    eventDetails.getUser(), eventDetails.getChannelId(), eventDetails.getText());
+
+            // 명령어를 파싱하는 메서드를 호출
+            ParsedCommand parsedCommand = parseCommand(eventDetails.getText());
+
+            if (parsedCommand != null) {
+                // 서버로 응답 내용을 전송하여 SMS로 답변 처리
+                interactionService.processInquiryResponse(parsedCommand.getInquiryId(), parsedCommand.getAnswer());
+                return "OK";
+            } else {
+                log.error("Failed to parse command from text: {}", eventDetails.getText());
+                return "Error: Invalid command format.";
+            }
+        }
+        return "OK";
+    }
+
+    // EventDetails 객체로 파싱하는 메서드
+    private EventDetails parseEventDetails(Map<String, Object> payload) {
+        try {
+            String eventType = (String) payload.get("type");
+
+            if ("event_callback".equals(eventType)) {
+                Map<String, Object> event = (Map<String, Object>) payload.get("event");
+                String type = (String) event.get("type");
+                String channelId = (String) event.get("channel");
+                String user = (String) event.get("user");
+                String text = (String) event.get("text");
+
+                return new EventDetails(eventType, type, channelId, user, text);
+            }
+        } catch (ClassCastException e) {
+            log.error("Failed to parse event details from payload: {}", payload, e);
+        }
+        return null; // 파싱 실패 시 null 반환
+    }
+
+    // 명령어를 파싱하는 메서드
+    private ParsedCommand parseCommand(String text) {
+        try {
+            // "/answer :"을 기준으로 메시지를 나눔
+            if (text.contains("/answer :")) {
+                String[] parts = text.split("/answer :");
+
+                if (parts.length >= 2) {
+                    String[] inquiryAndAnswer = parts[1].split("\n", 2); // 첫 번째 줄에서 inquiryId를, 두 번째 줄에서 답변을 추출
+
+                    if (inquiryAndAnswer.length >= 2) {
+                        Long inquiryId = Long.valueOf(inquiryAndAnswer[0].trim()); // inquiryId를 공백 제거 후 숫자로 변환
+                        String answer = inquiryAndAnswer[1].trim(); // 답변 내용의 앞뒤 공백 제거
+                        return new ParsedCommand(inquiryId, answer);
+                    }
+                }
+            }
+        } catch (NumberFormatException e) {
+            log.error("Failed to parse inquiryId from text: {}", text, e);
+        }
+        return null; // 파싱에 실패한 경우 null 반환
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private static class EventDetails {
+        private final String eventType;
+        private final String type;
+        private final String channelId;
+        private final String user;
+        private final String text;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private static class ParsedCommand {
+        private final Long inquiryId;
+        private final String answer;
+    }
+}

--- a/src/main/java/com/now_here5/now_here/infra/slack/service/SlackInquiryHandlerService.java
+++ b/src/main/java/com/now_here5/now_here/infra/slack/service/SlackInquiryHandlerService.java
@@ -1,0 +1,47 @@
+package com.now_here5.now_here.infra.slack.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SlackInquiryHandlerService {
+    @Value("${slack.inquiry.webhook.url}")
+    private String inquiryWebhookUrl;
+    private final RestTemplate restTemplate;
+
+    public void sendSlackNotification(Long inquiryId, String inquiryContent, String sourceInfo) {
+        HttpEntity<String> entity = getStringHttpEntity(inquiryId, inquiryContent, sourceInfo);
+
+        ResponseEntity<String> response = restTemplate.exchange(inquiryWebhookUrl, HttpMethod.POST, entity, String.class);
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            System.out.println("Message sent to Slack successfully.");
+        } else {
+            System.out.println("Failed to send message to Slack: " + response.getStatusCode());
+        }
+    }
+
+    private HttpEntity<String> getStringHttpEntity(Long inquiryId, String inquiryContent, String sourceInfo) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json, charset=UTF-8");
+
+        String payload = String.format("{\"channel\": \"#운영-문의사항\", \"text\": \"[문의사항]\\n" +
+                        "*Inquiry ID:* %d\\n" +
+                        "*휴대폰:* %s\\n" +
+                        "*문의내용:* %s\"}",
+                inquiryId, inquiryContent, sourceInfo);
+
+
+        HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+        return entity;
+    }
+}

--- a/src/main/java/com/now_here5/now_here/infra/slack/service/SlackNotificationService.java
+++ b/src/main/java/com/now_here5/now_here/infra/slack/service/SlackNotificationService.java
@@ -1,0 +1,39 @@
+package com.now_here5.now_here.infra.slack.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+
+public class SlackNotificationService {
+    @Value("${slack.notification.webhook.url}")
+    private String webhookUrl;
+    private final RestTemplate restTemplate;
+
+    public void sendNotification(String message) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json; charset=UTF-8"); // UTF-8로 메시지를 인코딩
+
+        String payload = String.format("{\"text\": \"%s\"}", message);
+
+        HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(webhookUrl, HttpMethod.POST, entity, String.class);
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            log.info("Message sent to Slack successfully.");
+        } else {
+            log.error("Failed to send message to Slack: {}", response.getStatusCode());
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=now_here
 
 spring.profiles.include = development
 spring.config.import=optional:classpath:key.properties
-
+logging.level.com.now_here5.now_here=INFO
 # allow every network interface : 0.0.0.0 <=> only local :  127.0.0.1
 server.address=0.0.0.0
 
@@ -30,3 +30,7 @@ scheduling.thread.pool.size=10
 # custom xor bidirectional encryption properties
 # 8 bits key
 custom.xor.key=${XOR_KEY}
+
+# slack properties
+slack.notification.webhook.url=${SLACK_WEBHOOK_URL}
+slack.inquiry.webhook.url=${SLACK_INQUIRY_WEBHOOK_URL}

--- a/src/test/java/com/now_here5/now_here/infra/slack/controller/SlackEventControllerTest.java
+++ b/src/test/java/com/now_here5/now_here/infra/slack/controller/SlackEventControllerTest.java
@@ -1,0 +1,56 @@
+package com.now_here5.now_here.infra.slack.controller;
+
+import com.now_here5.now_here.infra.slack.service.SlackEventService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class SlackEventControllerTest {
+
+    @Mock
+    private SlackEventService slackEventService;
+
+    @InjectMocks
+    private SlackEventController slackEventController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void handleSlackEvent_Success() {
+        // Given
+        Map<String, Object> payload = new HashMap<>();
+        when(slackEventService.processSlackEvent(payload)).thenReturn("OK");
+
+        // When
+        String response = slackEventController.handleSlackEvent(payload);
+
+        // Then
+        assertEquals("OK", response);
+        verify(slackEventService, times(1)).processSlackEvent(payload);
+    }
+
+    @Test
+    void handleSlackEvent_ShouldHandleException() {
+        // Given
+        Map<String, Object> payload = new HashMap<>();
+        when(slackEventService.processSlackEvent(payload)).thenThrow(new RuntimeException("Unexpected Error"));
+
+        // When
+        String response = slackEventController.handleSlackEvent(payload);
+
+        // Then
+        assertEquals("Error: An unexpected error occurred.", response);
+        verify(slackEventService, times(1)).processSlackEvent(payload);
+    }
+}

--- a/src/test/java/com/now_here5/now_here/infra/slack/service/SlackInquiryHandlerServiceTest.java
+++ b/src/test/java/com/now_here5/now_here/infra/slack/service/SlackInquiryHandlerServiceTest.java
@@ -1,0 +1,63 @@
+package com.now_here5.now_here.infra.slack.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "slack.inquiry.webhook.url=https://hooks.slack.com/services/your-webhook-url"
+})
+class SlackInquiryHandlerServiceTest {
+
+    @Value("${slack.inquiry.webhook.url}")
+    private String inquiryWebhookUrl;
+
+    private SlackInquiryHandlerService slackInquiryHandlerService;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        slackInquiryHandlerService = new SlackInquiryHandlerService(restTemplate);
+    }
+
+    @Test
+    void sendSlackNotification_RealRequest() {
+        // Given
+        Long inquiryId = 1L;
+        String inquiryContent = "This is a test inquiry content.";
+        String sourceInfo = "Test Source Info";
+
+        // When
+        ResponseEntity<String> response = sendRequest(inquiryId, inquiryContent, sourceInfo);
+
+        // Then
+        assertEquals(200, response.getStatusCodeValue());
+        System.out.println("Response from Slack: " + response.getBody());
+    }
+
+    private ResponseEntity<String> sendRequest(Long inquiryId, String inquiryContent, String sourceInfo) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json; charset=UTF-8");
+
+        String payload = String.format("{\"channel\": \"#your-channel\", \"text\": \"[Inquiry]\\n" +
+                        "*Inquiry ID:* %d\\n" +
+                        "*Source Info:* %s\\n" +
+                        "*Content:* %s\"}",
+                inquiryId, sourceInfo, inquiryContent);
+
+        HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        return restTemplate.exchange(inquiryWebhookUrl, HttpMethod.POST, entity, String.class);
+    }
+}

--- a/src/test/java/com/now_here5/now_here/infra/slack/service/SlackNotificationServiceTest.java
+++ b/src/test/java/com/now_here5/now_here/infra/slack/service/SlackNotificationServiceTest.java
@@ -1,0 +1,45 @@
+package com.now_here5.now_here.infra.slack.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SlackNotificationServiceTest {
+    private static final String WEBHOOK_URL = "your-webhook-url";
+    private RestTemplate restTemplate;
+    private SlackNotificationService slackNotificationService;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+        slackNotificationService = new SlackNotificationService(restTemplate);
+        ReflectionTestUtils.setField(slackNotificationService, "webhookUrl", WEBHOOK_URL);
+    }
+
+    @Test
+    void sendNotification() {
+        // Arrange
+        String testMessage = "[Now, here] 매칭 알림 \n 매칭 성공! \n 왕밤빵과 매칭되었어요!";
+        String expectedPayload = String.format("{\"text\": \"%s\"}", testMessage);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json; charset=UTF-8");
+
+        // Act
+        slackNotificationService.sendNotification(testMessage);
+
+        // 실제로 메시지가 전송되었는지 확인하려면 아래 코드를 사용
+        ResponseEntity<String> response = restTemplate.exchange(WEBHOOK_URL, HttpMethod.POST, new HttpEntity<>(expectedPayload, headers), String.class);
+
+        // Assert
+        assertEquals(200, response.getStatusCodeValue());
+        System.out.println("Response: " + response.getBody());
+    }
+}


### PR DESCRIPTION
Closes #10 

### PR 타입 : 기능 추가

### 반영 브랜치
`feature/10_service_management-> dev`

## PR 설명
이 PR은 Slack 연동 기능을 추가하여 문의사항 처리 및 알림 테스트를 포함한 여러 기능을 구현한 내용을 다룹니다. 주요 변경 사항은 다음과 같습니다:

### 완료한 작업 상세 내용

1. **이벤트 ID 암/복호화 기능 구현 및 테스트**
   - 이벤트 ID를 안전하게 저장하고 전송하기 위해 CustomXOR 로직을 컨트롤러 단에 추가했습니다.
   - 포스트맨(Postman)을 사용하여 해당 기능에 대한 테스트를 완료했습니다.

2. **Slack 연동 기능 추가**
   - 문의 사항이 Slack으로 알림이 가도록 설정하였고, Slack에서 문의에 응답할 수 있는 기능을 추가했습니다.
   - Slack의 `url_verification`을 처리하여 알림이 정확하게 전달되는지 검증했습니다.

3. **파이프라인 설정 변경**
   - 파이프라인에 XOR 키를 추가하여 암호화 기능을 강화했습니다.

## 고민과 해결과정
- **이벤트 아이디 암/복호화**: 서비스 기획상 event id가 포함된 URL을 클라이언트 측에 제공하여 유저가 회원가입할 때 특정 이벤트에 맵핑되도록 했습니다. 이때 event id가 숫자로 전달되는 경우, 이를 파악하고 수정할 수 있는 가능성을 차단하기 위해 간단한 암호화 (숫자 ^ key, base64Encode)를 적용했습니다.
- **Slack 스레드 활용**: SMS 서비스의 비용 문제를 해결하기 위해 Slack을 통해 유저 알림을 테스트하도록 구현했습니다. 고객의 문의사항에 대한 응답도 Slack을 통해 처리할 수 있도록 구성했습니다.
- **Slack 연동 시 URL 검증 문제**: Slack의 `url_verification` 처리 로직을 추가하여, 슬랙 알림이 정확하게 동작하도록 조치했습니다.

## 📸 스크린샷

### 슬랙

- SMS 알림 대체용 알림 스레드
![image](https://github.com/user-attachments/assets/92dcd63f-0afc-4479-ab28-72b4c480c029)

- 유저 문의사항 응대 스레드
![image](https://github.com/user-attachments/assets/31bf5b68-c1b6-4ecb-96ef-1b5e0118a62c)
