### PR TITLE
Feat  : #19 - 팝업 상태 조회

### DIFF
--- a/src/main/java/com/now_here5/now_here/admin/controller/EventAdminController.java
+++ b/src/main/java/com/now_here5/now_here/admin/controller/EventAdminController.java
@@ -31,7 +31,6 @@ import java.util.List;
 public class EventAdminController {
     private final EventService eventService;
     private final EventSchedulerService eventSchedulerService;
-    private final CustomXOR customXOR;
 
     @Operation(summary = "이벤트 목록 조회", description = "상태에 따라 이벤트 목록을 조회합니다.")
     @Parameter(name = "status", description = "이벤트 상태", required = true, schema = @Schema(example = "true"))

--- a/src/main/java/com/now_here5/now_here/admin/controller/EventAdminController.java
+++ b/src/main/java/com/now_here5/now_here/admin/controller/EventAdminController.java
@@ -50,48 +50,49 @@ public class EventAdminController {
     }
 
     @Operation(summary = "이벤트 상세 조회", description = "이벤트 ID를 사용하여 이벤트의 세부 정보를 조회합니다.")
-    @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "MTAyOTM4NDY"))
+    @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1"))
     @ApiResponse(responseCode = "200", description = "E005 - 이벤트 상세 조회 성공")
     @ApiResponse(responseCode = "400", description = "E006 - 이벤트 상세 조회 실패")
 
     @GetMapping("/detail/{event_id}")
     public ResponseEntity<ResponseForm> getSingleEvent(
-            @PathVariable(name = "event_id") String eventId) {
+            @PathVariable(name = "event_id") Long eventId) {
 
-        EventResponse eventDetail = eventService.getEventDetail(customXOR.decrypt(eventId));
+        EventResponse eventDetail = eventService.getEventDetail(eventId);
 
         return eventDetail != null ?
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.EVENT_QUERY_SUCCESS, eventDetail)) :
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.EVENT_QUERY_FAIL));
     }
 
-    @Operation(summary = "이벤트 삭제", description = "이벤트 ID를 사용하여 이벤트를 삭제합니다.")
-    @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "MTAyOTM4NDY"))
+    @Operation(summary = "이벤트 업데이트", description = "이벤트 ID를 사용하여 이벤트를 업데이트합니다.")
+    @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1"))
     @ApiResponse(responseCode = "200", description = "E009 - 이벤트 삭제 성공")
     @ApiResponse(responseCode = "400", description = "E010 - 이벤트 삭제 실패")
 
     @PatchMapping("/update/{event_id}")
-    public ResponseEntity<ResponseForm> deleteEvent(
-            @PathVariable(name = "event_id") String eventId,
+    public ResponseEntity<ResponseForm> updateEvent(
+            @PathVariable(name = "event_id") Long eventId,
             @RequestBody NewEventRequest request) {
-        boolean result = eventSchedulerService.updateEvent(request, customXOR.decrypt(eventId));
+
+        boolean result = eventSchedulerService.updateEvent(request, eventId);
 
         return result ?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.EVENT_DELETE_SUCCESS)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.EVENT_DELETE_FAIL));
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.EVENT_UPDATE_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.EVENT_UPDATE_FAIL));
     }
 
     @Operation(summary = "이벤트 종료", description = "이벤트 ID를 사용하여 이벤트를 종료합니다.")
-    @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "MTAyOTM4NDY"))
+    @Parameter(name = "event_id", description = "이벤트 ID", required = true, schema = @Schema(example = "1"))
     @ApiResponse(responseCode = "200", description = "E007 - 이벤트 종료 성공")
     @ApiResponse(responseCode = "400", description = "E008 - 이벤트 종료 실패")
 
     @DeleteMapping("/close/{event_id}")
     public ResponseEntity<ResponseForm> closeEventWithMembers(
-            @PathVariable(name = "event_id") String eventId) {
+            @PathVariable(name = "event_id") Long eventId) {
 
         try {
-            eventSchedulerService.closeEventWithMembers(customXOR.decrypt(eventId));
+            eventSchedulerService.closeEventWithMembers(eventId);
             return ResponseEntity.ok(ResponseForm.of(ResponseCode.EVENT_CLOSE_SUCCESS));
         } catch (Exception e) {
             log.error("Failed to close event: {}", e.getMessage());
@@ -100,6 +101,7 @@ public class EventAdminController {
 
     }
 
+    
     @Operation(summary = "이벤트 생성", description = "새로운 이벤트를 생성합니다.")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = "새로운 이벤트 요청",

--- a/src/main/java/com/now_here5/now_here/domain/interaction/controller/InteractionController.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/controller/InteractionController.java
@@ -53,6 +53,22 @@ public class InteractionController {
         }
     }
 
+    @Operation(summary = "팝업 상태 조회", description = "사용자에게 팝업을 뜨워야할지 판단합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponse(responseCode = "200", description = "I001 - 문의 작성에 성공했습니다.")
+    @ApiResponse(responseCode = "400", description = "I001 - 문의 작성에 실패했습니다.")
+    @GetMapping("/feedback/status")
+    public ResponseEntity<ResponseForm> getFeedbackStatus() {
+
+        try{
+            boolean status = interactionService.getFeedbackStatus();
+            return ResponseEntity.ok(ResponseForm.of(ResponseCode.FEEDBACK_STATUS_SUCCESS, status));
+        }catch(Exception e){
+            log.error("피드백 팝업 상태 조회 중 오류 발생: {}", e.getMessage());
+            return ResponseEntity.ok(ResponseForm.of(ResponseCode.FEEDBACK_STATUS_FAIL));
+
+        }
+    }
+
 //    // DTO 형태로 변경
 //    @Operation(summary = "사용자의 피드백 조회", description = "사용자가 작성한 피드백을 조회합니다.")
 //    @GetMapping("/feedback/{memberId}")

--- a/src/main/java/com/now_here5/now_here/domain/interaction/entity/Feedback.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/entity/Feedback.java
@@ -21,6 +21,7 @@ public class Feedback extends Interaction{
     @Max(5)  // 최대값 5
     private int field;  // 별점
 
+
     @Builder
     public Feedback(String content, Member member, int field) {
         super(content, member);

--- a/src/main/java/com/now_here5/now_here/domain/interaction/entity/Feedback.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/entity/Feedback.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "feedback")
 public class Feedback extends Interaction{
 
-    @Column(name = "field", nullable = true)
+    @Column(name = "field")
 //    @Min(1)  // 최소값 1
     @Max(5)  // 최대값 5
     private int field;  // 별점

--- a/src/main/java/com/now_here5/now_here/domain/interaction/entity/Inquiry.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/entity/Inquiry.java
@@ -1,14 +1,11 @@
 package com.now_here5.now_here.domain.interaction.entity;
 
 import com.now_here5.now_here.domain.member.entity.Member;
-import com.now_here5.now_here.global.entity.FullAudit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
-
 import java.time.LocalDateTime;
 
 @Getter
@@ -17,10 +14,10 @@ import java.time.LocalDateTime;
 @Table(name = "inquiry")
 public class Inquiry extends Interaction {
 
-    @Column(name = "phone_number", nullable = true)
+    @Column(name = "phone_number")
     private String phoneNumber;
 
-    @Column(name = "answer", nullable = true)
+    @Column(name = "answer")
     private String answer;
 
     @Column(name = "answered_at")

--- a/src/main/java/com/now_here5/now_here/domain/interaction/entity/Inquiry.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/entity/Inquiry.java
@@ -1,11 +1,15 @@
 package com.now_here5.now_here.domain.interaction.entity;
 
 import com.now_here5.now_here.domain.member.entity.Member;
+import com.now_here5.now_here.global.entity.FullAudit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -19,6 +23,9 @@ public class Inquiry extends Interaction {
     @Column(name = "answer", nullable = true)
     private String answer;
 
+    @Column(name = "answered_at")
+    private LocalDateTime answeredAt; // 답변 시간 (답변이 있을 때만 해당)
+
     @Builder
     public Inquiry(String content, Member member, String phoneNumber, String answer) {
         super(content, member);
@@ -29,5 +36,6 @@ public class Inquiry extends Interaction {
     // 답변을 업데이트하는 메서드
     public void updateAnswer(String answer) {
         this.answer = answer;
+        this.answeredAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/now_here5/now_here/domain/interaction/entity/Interaction.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/entity/Interaction.java
@@ -3,7 +3,6 @@ package com.now_here5.now_here.domain.interaction.entity;
 
 import com.now_here5.now_here.domain.member.entity.Member;
 import com.now_here5.now_here.global.entity.CreatedDateAudit;
-import com.now_here5.now_here.global.entity.FullAudit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,7 +15,7 @@ public abstract class Interaction extends CreatedDateAudit {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "interation_id", nullable = false, updatable = true)
+    @Column(name = "interation_id", nullable = false)
     private Long id;
 
     @Column(name = "content", nullable = false)

--- a/src/main/java/com/now_here5/now_here/domain/interaction/entity/Interaction.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/entity/Interaction.java
@@ -2,6 +2,8 @@
 package com.now_here5.now_here.domain.interaction.entity;
 
 import com.now_here5.now_here.domain.member.entity.Member;
+import com.now_here5.now_here.global.entity.CreatedDateAudit;
+import com.now_here5.now_here.global.entity.FullAudit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public abstract class Interaction {
+public abstract class Interaction extends CreatedDateAudit {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/now_here5/now_here/domain/interaction/repository/InteractionRepository.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/repository/InteractionRepository.java
@@ -14,6 +14,8 @@ public interface InteractionRepository {
 
     void saveWithdrawalReason(WithdrawalReason withdrawalReason);
 
+    boolean isFeedbackFullyWrittenToday(Long memberId);
+
     Feedback findFeedbackById(Long id);
 
     Inquiry findInquiryById(Long id);

--- a/src/main/java/com/now_here5/now_here/domain/interaction/repository/InteractionRepositoryImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/repository/InteractionRepositoryImpl.java
@@ -52,6 +52,21 @@ public class InteractionRepositoryImpl implements InteractionRepository {
     }
 
     @Override
+    public boolean isFeedbackFullyWrittenToday(Long memberId) {
+        try{
+            return em.createQuery("select count(f) from Feedback f " +
+                            "where f.member.id = :memberId " +
+                            "and f.field is not null " +
+                            "and f.createdAt >= current_date", Long.class)
+                    .setParameter("memberId", memberId)
+                    .getSingleResult() >= 1;
+        } catch (Exception e) {
+            log.error("오늘 FULL 피드백 작성 여부 조회에 실패했습니다: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
     public Feedback findFeedbackById(Long id) {
         try {
             return em.find(Feedback.class, id);

--- a/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionService.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionService.java
@@ -25,4 +25,5 @@ public interface InteractionService {
 
     void processInquiryResponse(Long inquiryId, String answer);
 
+    boolean getFeedbackStatus();
 }

--- a/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionServiceImpl.java
@@ -8,6 +8,7 @@ import com.now_here5.now_here.domain.interaction.entity.Feedback;
 import com.now_here5.now_here.domain.interaction.entity.Inquiry;
 import com.now_here5.now_here.domain.interaction.entity.WithdrawalReason;
 import com.now_here5.now_here.domain.interaction.repository.InteractionRepository;
+import com.now_here5.now_here.domain.matching.repository.MatchingRepository;
 import com.now_here5.now_here.domain.member.entity.Member;
 import com.now_here5.now_here.domain.member.repository.MemberRepository;
 import com.now_here5.now_here.global.util.AuthUtil;
@@ -30,6 +31,7 @@ public class InteractionServiceImpl implements InteractionService {
     private final AuthUtil authUtil;
     private final SlackInquiryHandlerService slackInquiryHandlerService;
     private final NotificationService notificationService;
+    private final MatchingRepository matchingRepository;
 
     @Transactional
     @Override
@@ -86,6 +88,104 @@ public class InteractionServiceImpl implements InteractionService {
             log.info("Inquiry not found for ID: {}", inquiryId);
         }
     }
+
+
+/* (의견남기기 요구) 팝업이 뜨는 경우
+1. 계정 기준: 최초 한번, 매칭 후 매칭 현황 페이지 접속했을 때 (매칭이 되었을 때만)
+2. 하루 기준: 오늘 매칭 페이지에 "3번째" 접속했을 때 팝업이 뜨도록 설정 (첫 번째, 두 번째, 4번째 이후에는 팝업 없음)
+3. 하루 기준: 오늘 한 번이라도 의견을 full로 작성하지 않은 사용자 (의견과 별점을 모두 남긴 사람은 패스, 의견만 남긴 사용자에게는 위의 1번 또는 2번 조건 적용)
+*/
+
+/* 로직 설명
+1. 최초 한번 매칭 후 매칭 현황 페이지 접속 시:
+    - 매칭이 되었는지 확인 (매칭 테이블에서 현재 사용자 ID로 매칭된 accepted 상태가 있으면 true, 없으면 false 반환).
+    - TODO: boolean isMatched(member_id) 메서드 작성 필요.
+
+2. 하루 기준 오늘 매칭 페이지 3번째 접속 시:
+    - getFeedbackStatus() 메서드가 호출될 때마다 popUpCount를 업데이트하고, 현재 카운트를 바탕으로 팝업 표시 여부 결정.
+    - popUpCount가 4일 때 true를 반환하여 팝업 표시, 그 외에는 false 반환.
+    - TODO: int updatePopupCount(int num) 메서드 작성 필요.
+
+3. 하루 기준 오늘 의견을 full로 작성하지 않은 경우:
+    - 오늘 작성된 피드백(의견과 별점 모두)이 있는지 확인하여, 있으면 false, 없으면 true 반환.
+    - TODO: boolean isFeedbackFullyWrittenToday(member_id) 메서드 작성 필요.
+*/
+
+/* 확인 순서:
+1. Step 1: 오늘 작성된 피드백(의견과 별점 모두) 확인 [(별점 && 내용) != null]. 작성된 피드백이 있으면 return false하고 2번, 3번 쿼리를 생략.
+2. Step 2: 매칭 상태 확인. 매칭이 없을 경우 불필요한 쿼리 발생 가능성 있음. 따라서 먼저 피드백을 확인한 후, 매칭 여부 확인.
+3. Step 3: 매칭이 확인된 경우 popUpCount를 확인하여, popUpCount가 4이면 true를 반환하고 팝업을 띄움. 그렇지 않으면 false 반환.
+4. Step 4: popUpCount가 4가 아니면 매칭 여부 확인 후, 매칭이 되지 않았으면 true, 되었으면 false 반환.
+
+// 전체 흐름 정리:
+1. 사용자가 매칭 페이지로 이동하는 버튼을 클릭할 때, GET 요청을 보냄 (base_url/interaction/feedback/status).
+2. 서버에서 팝업을 띄울지 여부를 판단.
+3. 결과로 boolean 값을 반환 (true: 팝업 표시, false: 팝업 미표시).
+4. 하루에 한 번, 스케줄러가 실행되어 모든 사용자의 팝업 카운트를 초기화
+    - 음수인 경우 0으로 초기화
+    - 양수인 경우 1로 초기화
+*/
+
+
+
+    @Override
+    public boolean getFeedbackStatus() {
+
+        try{
+            Long memberId = authUtil.getMemberByAuthentication().getMemberId();
+
+            // Step 1: 오늘 피드백을 작성했는지 확인
+            if (isFeedbackFullyWrittenToday(memberId)) {
+                return false;
+            }
+
+            Member member = memberRepository.findMemberById(memberId);
+            if (member == null) {
+                log.warn("Member not found for ID: {}", memberId);
+                return false;
+            }
+
+            int currentCount = member.getPopupCount();
+
+            // Step 2: 매칭이 되었는지 확인
+            boolean matched = isMatched(memberId);
+
+            // Step 3: 팝업 로직
+            if (currentCount == 0) { // 첫 접근
+                if (matched) {
+                    member.updatePopupCount(2); // 최초 팝업 후 카운트 2로 설정
+                    return true; // 팝업 띄우기
+                } else {
+                    member.updatePopupCount(-2); // 매칭이 안 되었으므로 음수로 카운트
+                    return false;
+                }
+            } else if (isPopupRequired(currentCount)) { // 이미 카운트가 4인 경우: 팝업 이미 뜬 상태
+                return false; // update 쿼리 생략하고, 팝업 띄우지 않음
+            } else if (currentCount > 0) { // 팝업이 이미 한번 뜬 경우
+                int updatedCount = member.updatePopupCount(currentCount + 1);
+                return isPopupRequired(updatedCount); // 3번째 접근 시 팝업 띄우기
+            } else { // 최초 매칭이 안 되어 음수 카운트 중인 경우
+                int updatedCount = member.updatePopupCount(currentCount - 1);
+                return isPopupRequired(updatedCount); // 3번째 접근 시 팝업 띄우기
+            }
+        }catch (Exception e){
+            log.error("피드백 팝업 상태 조회 중 오류 발생: {}", e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    private boolean isMatched(Long memberId) {
+        return !matchingRepository.findAcceptedMatchingsBySenderOrReceiver(memberId).isEmpty();
+    }
+
+    private boolean isFeedbackFullyWrittenToday(Long memberId) {
+        return interactionRepository.isFeedbackFullyWrittenToday(memberId);
+    }
+
+    private boolean isPopupRequired(int count) {
+        return Math.abs(count) == 4;
+    }
+
 
     @Transactional
     @Override

--- a/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/interaction/service/InteractionServiceImpl.java
@@ -127,7 +127,7 @@ public class InteractionServiceImpl implements InteractionService {
 */
 
 
-
+    @Transactional
     @Override
     public boolean getFeedbackStatus() {
 
@@ -142,7 +142,7 @@ public class InteractionServiceImpl implements InteractionService {
             Member member = memberRepository.findMemberById(memberId);
             if (member == null) {
                 log.warn("Member not found for ID: {}", memberId);
-                return false;
+                throw new RuntimeException("Member not found for ID: " + memberId);
             }
 
             int currentCount = member.getPopupCount();

--- a/src/main/java/com/now_here5/now_here/domain/member/controller/MemberInfoController.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/controller/MemberInfoController.java
@@ -112,15 +112,30 @@ public class MemberInfoController {
             )
     )
 
-    @PatchMapping("/update/notification")
+    @PatchMapping("/update/notification-setting")
     public ResponseEntity<ResponseForm> updateNotification(
             @RequestBody UpdateNotificationRequest updateNotificationRequest) {
 
-        boolean updated = memberService.updateNotification(updateNotificationRequest.isNotification());
+        boolean updated = memberService.updateNotificationSetting(updateNotificationRequest.isNotification());
 
         return updated ?
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.TOGGLE_NOTIFICATION_SUCCESS)) :
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.TOGGLE_NOTIFICATION_FAIL));
+    }
+
+
+    @Operation(summary = "알림 설정 조회", description = "회원의 알림 설정을 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponse(responseCode = "200", description = "M009 - 알림 설정 조회에 성공했습니다.")
+    @ApiResponse(responseCode = "400", description = "M009 - 알림 설정 조회에 실패했습니다.")
+    @GetMapping("/notification-setting")
+    public ResponseEntity<ResponseForm> getNotificationSetting() {
+        try {
+            boolean notificationSetting = memberService.getNotificationSetting();
+            return ResponseEntity.ok(ResponseForm.of(ResponseCode.TOGGLE_NOTIFICATION_SUCCESS, notificationSetting));
+        } catch (Exception e) {
+            log.error("알림 설정 조회에 실패했습니다: {}", e.getMessage());
+            return ResponseEntity.ok(ResponseForm.of(ResponseCode.TOGGLE_NOTIFICATION_FAIL));
+        }
     }
 
     @Operation(summary = "닉네임 업데이트", description = "회원의 닉네임을 업데이트합니다.", security = @SecurityRequirement(name = "bearerAuth"))

--- a/src/main/java/com/now_here5/now_here/domain/member/converter/RegisterDtoToMember.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/converter/RegisterDtoToMember.java
@@ -27,7 +27,6 @@ public class RegisterDtoToMember {
                 .password(encryptedPassword)
                 .nickname(registerRequest.getNickname())
                 .gender(Gender.valueOf(registerRequest.getGender().toUpperCase()))
-                .notification(true)
                 .active(true)
                 .mbti(MBTI.valueOf(registerRequest.getMbti().toUpperCase()))
                 .token(tokenGenerator.generateUniqueToken())

--- a/src/main/java/com/now_here5/now_here/domain/member/dto/LoginResponse.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/dto/LoginResponse.java
@@ -13,5 +13,5 @@ import java.util.List;
 @Builder
 public class LoginResponse {
     private final TokenDto token;
-    private final EventListResponse eventListResponse;
+//    private final EventListResponse eventListResponse;
 }

--- a/src/main/java/com/now_here5/now_here/domain/member/entity/Member.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/entity/Member.java
@@ -3,7 +3,6 @@ package com.now_here5.now_here.domain.member.entity;
 import com.now_here5.now_here.domain.event.entity.Event;
 import com.now_here5.now_here.domain.matching.entity.Matching;
 import com.now_here5.now_here.domain.member.entity.role.MemberRole;
-import com.now_here5.now_here.global.entity.CreatedDateAudit;
 import com.now_here5.now_here.global.entity.FullAudit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -34,7 +33,7 @@ public class Member extends FullAudit {
     @Column(name = "member_id", nullable = false, unique = true)
     private Long id;
 
-    @Column(name = "token", nullable = true, unique = true)
+    @Column(name = "token", unique = true)
     private String token;
 
     @Column(name = "birthday", nullable = false)

--- a/src/main/java/com/now_here5/now_here/domain/member/entity/Member.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.now_here5.now_here.domain.member.entity;
 import com.now_here5.now_here.domain.event.entity.Event;
 import com.now_here5.now_here.domain.matching.entity.Matching;
 import com.now_here5.now_here.domain.member.entity.role.MemberRole;
+import com.now_here5.now_here.global.entity.CreatedDateAudit;
 import com.now_here5.now_here.global.entity.FullAudit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -26,7 +27,7 @@ import java.util.List;
         @UniqueConstraint(columnNames = {"event_id", "phone_num"}),
         @UniqueConstraint(columnNames = {"event_id", "nick_name"})
 })
-public class Member extends FullAudit  {
+public class Member extends FullAudit {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -59,13 +60,10 @@ public class Member extends FullAudit  {
     @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "notification", nullable = false)
-    private boolean notification;
+    @Column(name = "popupCount", nullable = false)
+    private int popupCount; // 하루에 몇번이나 매칭 페이지를 조회했는지. (4번 : 팝업, null : 첫 매칭 이전, 0 : 첫 매칭 이후  )
 
-    @Column(name = "popupStatus", nullable = false)
-    private int popupStatus; // 하루에 몇 번 팝업이 나왔는지
-
-    @Column(name = "unreadNotiCount", nullable = true)
+    @Column(name = "unreadNotiCount")
     private Integer unreadNotiCount;// 읽지 않는 알림의 개수
 
     @Column(name = "noti_setting", nullable = false)
@@ -89,7 +87,7 @@ public class Member extends FullAudit  {
 
     @Builder
     public Member(String token, LocalDate birthday, String phoneNumber, String nickname, String password,
-                  Gender gender, MBTI mbti, String description, boolean notification, boolean active,
+                  Gender gender, MBTI mbti, String description, boolean active,
                   Event event) {
         this.token = token;
         this.birthday = birthday;
@@ -99,11 +97,11 @@ public class Member extends FullAudit  {
         this.gender = gender;
         this.mbti = mbti;
         this.description = description;
-        this.notification = notification;
         this.active = active;
         this.event = event;
         this.unreadNotiCount = 0;
         this.notiSetting = true;
+        this.popupCount = 0;
 
         // Add this member to the event's member list if it's not already present
         setEvent(event);
@@ -118,8 +116,12 @@ public class Member extends FullAudit  {
         this.description = newDescription;
     }
 
-    public void updateNotification(boolean newNotification) {
-        this.notification = newNotification;
+    public void updateNotiSetting(boolean notiSetting) {
+        this.notiSetting = notiSetting;
+    }
+
+    public int updatePopupCount(int num) {
+        return this.popupCount = num;
     }
 
     public void updateMbti(MBTI mbti) {

--- a/src/main/java/com/now_here5/now_here/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/repository/MemberRepository.java
@@ -21,5 +21,7 @@ public interface MemberRepository {
 
     void save(Member activeMember);
 
+    void initializePopupValue();
+
     List<Member> findMembersByMemberIdAndEventIdAndGender(Long memberId, Long eventId, Gender gender);
 }

--- a/src/main/java/com/now_here5/now_here/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/repository/MemberRepositoryImpl.java
@@ -101,13 +101,14 @@ public class MemberRepositoryImpl implements MemberRepository {
         }
     }
 
+
     @Override
     public void initializePopupValue() {
         try {
-            em.createNativeQuery("UPDATE Member SET popupCount = " +
+            em.createQuery("UPDATE Member SET popupCount = " +
                             "CASE " +
-                            "WHEN popupCount < 0 " +
-                            "THEN -1 ELSE 1 " +
+                            "WHEN popupCount <= 0 " +
+                            "THEN 0 ELSE 1 " +
                             "END")
             .executeUpdate();
         } catch (Exception e) {

--- a/src/main/java/com/now_here5/now_here/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/repository/MemberRepositoryImpl.java
@@ -102,6 +102,22 @@ public class MemberRepositoryImpl implements MemberRepository {
     }
 
     @Override
+    public void initializePopupValue() {
+        try {
+            em.createNativeQuery("UPDATE Member SET popupCount = " +
+                            "CASE " +
+                            "WHEN popupCount < 0 " +
+                            "THEN -1 ELSE 1 " +
+                            "END")
+            .executeUpdate();
+        } catch (Exception e) {
+            log.error("Failed to initialize popup value: {}", e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+
+    @Override
     public Member findMemberById(Long memberId) {
         try{
             return em.find(Member.class, memberId);

--- a/src/main/java/com/now_here5/now_here/domain/member/service/MemberAuthService.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/service/MemberAuthService.java
@@ -52,12 +52,8 @@ public class MemberAuthService {
 
             return LoginResponse.builder()
                     .token(new TokenDto(newToken))
-                    .eventListResponse(
-                            eventListToDto.converter(
-                                    eventRepository.getSignedEventsByMember(true,tempMember.getId())
-                            )
-                    )
                     .build();
+
         } catch (Exception e) {
             log.error("login Error ={}", e.getMessage());
             return null;

--- a/src/main/java/com/now_here5/now_here/domain/member/service/MemberPopupSchedulerService.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/service/MemberPopupSchedulerService.java
@@ -1,0 +1,21 @@
+package com.now_here5.now_here.domain.member.service;
+
+
+import com.now_here5.now_here.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MemberPopupSchedulerService {
+    private final MemberRepository memberRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void initializePopupByValue() {
+        log.info("initializePopupByValue");
+        memberRepository.initializePopupValue();
+    }
+}

--- a/src/main/java/com/now_here5/now_here/domain/member/service/MemberService.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/service/MemberService.java
@@ -26,9 +26,11 @@ public interface MemberService {
 
     EventListResponse getAssignedEventsByMember();
 
+    boolean getNotificationSetting();
+
     boolean updateDescription(String description);
 
-    boolean updateNotification(boolean notification);
+    boolean updateNotificationSetting(boolean notification);
 
     boolean updateNickName(String nickName);
 

--- a/src/main/java/com/now_here5/now_here/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/member/service/MemberServiceImpl.java
@@ -147,6 +147,18 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
+    @Override
+    public boolean getNotificationSetting() {
+        try{
+            AuthenticatedMemberDto memberDto = authUtil.getMemberByAuthentication();
+            Member member = memberRepository.findMemberById(memberDto.getMemberId());
+            return member.isNotiSetting();
+        }catch (Exception e){
+            log.error("Failed to get notification setting: {}", e.getMessage());
+            throw  new RuntimeException("Failed to get notification setting");
+        }
+    }
+
     @Transactional
     @Override
     public boolean updateDescription(String description) {
@@ -165,11 +177,11 @@ public class MemberServiceImpl implements MemberService {
 
     @Transactional
     @Override
-    public boolean updateNotification(boolean notification) {
+    public boolean updateNotificationSetting(boolean notiSetting) {
         try {
             AuthenticatedMemberDto memberDto = authUtil.getMemberByAuthentication();
             Member member = memberRepository.findMemberById(memberDto.getMemberId());
-            member.updateNotification(notification);
+            member.updateNotiSetting(notiSetting);
 
             return true;
         } catch (Exception e) {

--- a/src/main/java/com/now_here5/now_here/global/response/ResponseCode.java
+++ b/src/main/java/com/now_here5/now_here/global/response/ResponseCode.java
@@ -96,16 +96,21 @@ public enum ResponseCode {
     EVENT_DELETE_LOCATION_FAIL(400, "E008", "이벤트 장소 삭제에 실패했습니다."),
     EVENT_DELETE_SUCCESS(200, "E009", "이벤트 삭제에 성공했습니다."),
     EVENT_DELETE_FAIL(400, "E009", "이벤트 삭제에 실패했습니다."),
-    LOCATION_CREATE_SUCCESS(200, "E010", "장소 생성에 성공했습니다."),
-    LOCATION_CREATE_FAIL(400, "E010", "장소 생성에 실패했습니다."),
-    LOCATION_DELETE_SUCCESS(200, "E011", "장소 삭제에 성공했습니다."),
-    LOCATION_DELETE_FAIL(400, "E011", "장소 삭제에 실패했습니다."),
-    LOCATION_QUERY_SUCCESS(200, "E012", "장소 조회에 성공했습니다."),
-    LOCATION_QUERY_FAIL(400, "E012", "장소 조회에 실패했습니다."),
-    LOCATION_LIST_QUERY_SUCCESS(200, "E013", "장소 목록 조회에 성공했습니다."),
-    LOCATION_LIST_QUERY_FAIL(400, "E013", "장소 목록 조회에 실패했습니다."),
-    EVENTSCHEDULER_QUERY_SUCCESS(200, "E014", "이벤트 스케줄러 조회에 성공했습니다."),
-    EVENTSCHEDULER_QUERY_FAIL(400, "E014", "이벤트 스케줄러 조회에 실패했습니다."),
+
+    LOCATION_CREATE_SUCCESS(200, "E10", "장소 생성에 성공했습니다."),
+    LOCATION_CREATE_FAIL(400, "E10", "장소 생성에 실패했습니다."),
+    LOCATION_DELETE_SUCCESS(200, "E11", "장소 삭제에 성공했습니다."),
+    LOCATION_DELETE_FAIL(400, "E11", "장소 삭제에 실패했습니다."),
+    LOCATION_QUERY_SUCCESS(200, "E12", "장소 조회에 성공했습니다."),
+    LOCATION_QUERY_FAIL(400, "E12", "장소 조회에 실패했습니다."),
+    LOCATION_LIST_QUERY_SUCCESS(200, "E13", "장소 목록 조회에 성공했습니다."),
+    LOCATION_LIST_QUERY_FAIL(400, "E13", "장소 목록 조회에 실패했습니다."),
+    EVENTSCHEDULER_QUERY_SUCCESS(200, "E14", "이벤트 스케줄러 조회에 성공했습니다."),
+    EVENTSCHEDULER_QUERY_FAIL(400, "E14", "이벤트 스케줄러 조회에 실패했습니다."),
+    EVENT_UPDATE_SUCCESS(200, "E15", "이벤트 업데이트에 성공했습니다."),
+    EVENT_UPDATE_FAIL(400, "E15", "이벤트 업데이트에 실패했습니다."),
+    
+
     // Matching
     BANNER_LIST_QUERY_SUCCESS(200, "M001", "배너 목록 조회에 성공했습니다."),
     BANNER_LIST_QUERY_FAIL(400, "M001", "배너 목록 조회에 실패했습니다."),
@@ -138,8 +143,9 @@ public enum ResponseCode {
     INQUIRY_QUERY_SUCCESS(200, "I005", "INQUIRY 조회에 성공했습니다."),
     INQUIRY_QUERY_FAIL(400, "I005", "INQUIRY 조회에 실패했습니다."),
     WITHDRAWAL_REASON_QUERY_SUCCESS(200, "I006", "WITHDRAWAL_REASON 조회에 성공했습니다."),
-    WITHDRAWAL_REASON_QUERY_FAIL(400, "I006", "WITHDRAWAL_REASON 조회에 실패했습니다.");
-
+    WITHDRAWAL_REASON_QUERY_FAIL(400, "I006", "WITHDRAWAL_REASON 조회에 실패했습니다."),
+    FEEDBACK_STATUS_FAIL(400, "I007", "피드백 상태 조회에 실패했습니다."),
+    FEEDBACK_STATUS_SUCCESS(200, "I007", "피드백 상태 조회에 성공했습니다.");
     // field
     private final int status;
     private final String code;


### PR DESCRIPTION
Closes #19 

## 이슈 제목: [FEATURE] 매칭 테이블 외래 키 제약 조건 개선 및 피드백 팝업 로직 구현

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/19-popup-status -> dev

## PR 설명
매칭 테이블의 외래 키 제약 조건을 개선하고, 피드백 팝업 로직을 구현했습니다. 이 변경 사항은 `member` 테이블의 데이터 수정 시 발생하는 외래 키 충돌 문제를 해결하고, 매칭 현황 페이지에서 피드백 팝업을 적절히 표시하는 기능을 추가합니다.

## ✅ 완료한 기능 명세

- [x] 외래 키 제약 조건 수정: `matching` 테이블에서 `member` 테이블을 참조하는 외래 키 제약 조건에 `ON DELETE CASCADE` 및 `ON UPDATE CASCADE` 옵션을 추가하여, `member` 데이터 수정 시 참조 무결성 문제를 해결.
- [x] 피드백 팝업 로직 구현: 매칭 현황 페이지에서 사용자 피드백 상태에 따라 팝업이 적절히 표시되도록 하는 로직 추가.
- [x] 매일 밤 스케줄러를 통해 팝업 카운트를 초기화하는 기능 추가: 음수 카운트는 0으로, 양수 카운트는 1로 초기화.

## 📸 스크린샷
특정 기능 동작을 확인할 수 있는 스크린샷이나 GIF를 첨부합니다.

## 고민과 해결과정

### 문제점:
1. `member` 테이블에서 `active` 상태를 업데이트하거나 삭제하려고 할 때, `matching` 테이블의 외래 키 제약 조건으로 인해 SQL 예외가 발생하였습니다.
2. 매칭 현황 페이지에서 사용자가 피드백을 작성하지 않았을 때, 적절한 시점에 팝업이 표시되지 않는 문제.

### 해결 방법:
1. **외래 키 제약 조건 수정**:
   - 외래 키 제약 조건을 `ON DELETE CASCADE`, `ON UPDATE CASCADE`로 수정하여, 참조 무결성 문제를 해결했습니다.
   - `member` 테이블의 데이터를 수정하기 전에 `matching` 테이블의 참조 데이터를 먼저 처리하도록 로직을 수정했습니다.

2. **피드백 팝업 로직 구현**:
   - 사용자 피드백 상태에 따라 팝업을 표시하는 로직을 구현했습니다.
   - 구체적인 팝업 표시 조건은 다음과 같습니다:
     - **피드백 작성 여부 확인**: 사용자가 오늘 피드백을 작성하지 않았다면 팝업이 표시됩니다.
     - **매칭 완료 후 첫 접속 시**: 매칭이 완료된 후 사용자가 매칭 현황 페이지에 첫 번째로 접속할 때 팝업이 표시됩니다.
     - **하루 3번째 접속 시**: 사용자가 하루에 매칭 현황 페이지에 3번째로 접속했을 때 팝업이 표시됩니다.
     - **팝업 중복 방지**: 이미 팝업이 표시된 경우 추가적으로 팝업이 표시되지 않도록 로직을 구현했습니다.
   - 이 로직을 통해 팝업이 적절한 시점에 정확하게 표시되도록 하였습니다.

3. **스케줄러 구현**:
   - 매일 밤 스케줄러를 통해 사용자의 팝업 카운트를 초기화하는 기능을 추가했습니다.
   - 음수인 카운트는 0으로, 양수인 카운트는 1로 초기화하여 다음 날의 피드백 팝업 로직이 올바르게 작동하도록 했습니다.
