### PR TITLE
Feat : #61 - 이전에 보낸 하트를 삭제하는 기능

### DIFF
--- a/src/main/java/com/now_here5/now_here/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/now_here5/now_here/domain/matching/controller/MatchingController.java
@@ -45,7 +45,7 @@ public class MatchingController {
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = "하트 보내기 요청", required = true,
             content = @io.swagger.v3.oas.annotations.media.Content(schema = @Schema(implementation = HeartRequest.class),
-            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = "{\"receiverId\": 1, \"isSpecialUsed\": false}"))
+                    examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = "{\"receiverId\": 1, \"isSpecialUsed\": false}"))
     )
 
     @ApiResponse(responseCode = "200", description = "L002 - 하트 보내기 성공")
@@ -54,7 +54,7 @@ public class MatchingController {
     @PostMapping("/send")
     public ResponseEntity<ResponseForm> sendLove(@RequestBody HeartRequest request) {
         try {
-            boolean isNotificationSentWhenEnabled  = matchingService.sendLove(request.getReceiverId(), request.isSpecialUsed());
+            boolean isNotificationSentWhenEnabled = matchingService.sendLove(request.getReceiverId(), request.isSpecialUsed());
             return ResponseEntity.ok(ResponseForm.of(ResponseCode.LOVE_SEND_SUCCESS, isNotificationSentWhenEnabled));
         } catch (Exception e) {
             log.error("하트 보내기 중 오류 발생: {}", e.getMessage());
@@ -93,6 +93,18 @@ public class MatchingController {
             return ResponseEntity.ok(ResponseForm.of(ResponseCode.LOVE_REJECT_FAIL));
         }
     }
+    @Operation(summary = "하트 취소하기", description = "이전에 보낸 하트를 취소합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @Parameter(name = "receiverId", description = "내가 하트를 보낸 사람의 ID", required = true, schema = @Schema(example = "1"))
+    @ApiResponse(responseCode = "200", description = "L012 - 하트 취소 성공")
+    @ApiResponse(responseCode = "400", description = "L012 - 하트 취소 실패")
+    @DeleteMapping("/remove/heart")
+    public ResponseEntity<ResponseForm> removeHeart(@RequestParam Long receiverId) {
+        boolean isRemoved = matchingService.removeHeart(receiverId);
+        return isRemoved ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.HEART_REMOVAL_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.HEART_REMOVAL_FAIL));
+    }
+
 
     @Operation(summary = "매칭 요약 조회", description = "매칭 요약 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponse(responseCode = "200", description = "L005 - 요약 정보 조회 성공")
@@ -178,7 +190,7 @@ public class MatchingController {
     @ApiResponse(responseCode = "200", description = "L011 - 특별하트 개수 조회 성공")
     @ApiResponse(responseCode = "400", description = "L011 - 특별하트 개수 조회 실패")
     @GetMapping("/getSpecialHeart")
-    public ResponseEntity<ResponseForm> getSpecialHeartCount(){
+    public ResponseEntity<ResponseForm> getSpecialHeartCount() {
         Integer notificationCount = matchingService.getSpecialHeartCount();
 
         return notificationCount != null ?

--- a/src/main/java/com/now_here5/now_here/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/now_here5/now_here/domain/matching/repository/MatchingRepository.java
@@ -12,7 +12,7 @@ public interface MatchingRepository {
     void save(Matching matching);
     Matching findById(Long matchingId);
     void update(Matching matching);
-    void delete(Long matchingId);
+    void removeSentHeart(Long senderId, Long receiverId);
 
     // memberId가 receiver인 매칭의 수를 찾음
     Long countByReceiverId(Long memberId);

--- a/src/main/java/com/now_here5/now_here/domain/matching/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/matching/repository/MatchingRepositoryImpl.java
@@ -71,16 +71,16 @@ public class MatchingRepositoryImpl implements MatchingRepository {
     }
 
     @Override
-    public void delete(Long matchingId) {
-        try {
-            Matching matching = em.find(Matching.class, matchingId);
-            if (matching != null) {
-                em.remove(matching);
-            } else {
-                log.warn("ID로 매칭 못 찾음: {}", matchingId);
-            }
-        } catch (Exception e) {
-            log.error("ID로 매칭 삭제 중 실패: {}", matchingId, e);
+    public void removeSentHeart(Long senderId, Long receiverId) {
+        try{
+            em.createQuery("delete from Matching m where " +
+                            "m.sender.id =:senderId and " +
+                            "m.receiver.id =:receiverId")
+                    .setParameter("senderId", senderId)
+                    .setParameter("receiverId", receiverId)
+                    .executeUpdate();
+        }catch(Exception e) {
+            log.error("보낸 하트 취소 실패 : {}" , e.getMessage());
         }
     }
 

--- a/src/main/java/com/now_here5/now_here/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/now_here5/now_here/domain/matching/service/MatchingService.java
@@ -10,6 +10,8 @@ public interface MatchingService {
 
     boolean sendLove(Long receiverId, boolean isSpecialUsed);
 
+    boolean removeHeart(Long receiverId);
+
     void receiveLove(Long senderId);
 
     void rejectLove(Long senderId);
@@ -27,4 +29,6 @@ public interface MatchingService {
     Integer getNotificationCount();
 
     Integer getSpecialHeartCount();
+
+
 }

--- a/src/main/java/com/now_here5/now_here/domain/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/now_here5/now_here/domain/matching/service/MatchingServiceImpl.java
@@ -77,6 +77,18 @@ public class MatchingServiceImpl implements MatchingService {
         } else return !isSpecialUsed;
     }
 
+    @Transactional
+    @Override
+    public boolean removeHeart(Long receiverId) {
+        try {
+            AuthenticatedMemberDto member = authUtil.getMemberByAuthentication();
+            matchingRepository.removeSentHeart(member.getMemberId(), receiverId);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     private Matching createMatching(Member sender, Member receiver) {
         return Matching.builder()
                 .sender(sender)
@@ -99,10 +111,13 @@ public class MatchingServiceImpl implements MatchingService {
     }
 
     private SmsRequest createSmsRequest(Member receiver, String eventId) {
-        String url = switch(eventId) {
-            case "1" : yield "https://www.now-here.site/match/received-hearts?eventCode=MTAyOTM4NDY";
-            case "2" : yield "https://나우히어.lrl.kr";
-            case "3" : yield "https://나우히어_가을.lrl.kr";
+        String url = switch (eventId) {
+            case "1":
+                yield "https://www.now-here.site/match/received-hearts?eventCode=MTAyOTM4NDY";
+            case "2":
+                yield "https://나우히어.lrl.kr";
+            case "3":
+                yield "https://나우히어_가을.lrl.kr";
 
 
             default:
@@ -110,7 +125,7 @@ public class MatchingServiceImpl implements MatchingService {
         };
 
         return SmsRequest.builder()
-                .message("하트가 도착했어요! 지금 확인하고 응답해보세요 : "+url)
+                .message("하트가 도착했어요! 지금 확인하고 응답해보세요 : " + url)
                 .phoneNumber(receiver.getPhoneNumber())
                 .build();
     }
@@ -126,10 +141,13 @@ public class MatchingServiceImpl implements MatchingService {
         Long eventId = sender.getEvent().getId();
         //String encryptEventId = xor.encrypt(eventId);
 
-        String url = switch(eventId.toString()) {
-            case "1" : yield "https://www.now-here.site/match/status?eventCode=MTAyOTM4NDY";
-            case "2" : yield "https://_나우히어.lrl.kr";
-            case "3" : yield "https://가을_나우히어.lrl.kr";
+        String url = switch (eventId.toString()) {
+            case "1":
+                yield "https://www.now-here.site/match/status?eventCode=MTAyOTM4NDY";
+            case "2":
+                yield "https://_나우히어.lrl.kr";
+            case "3":
+                yield "https://가을_나우히어.lrl.kr";
 
             default:
                 throw new IllegalStateException("Unexpected value: " + eventId);
@@ -142,7 +160,7 @@ public class MatchingServiceImpl implements MatchingService {
                 matchingRepository.update(matching);
 
                 SmsRequest smsRequest = SmsRequest.builder()
-                        .message("매칭되었습니다! 지금 바로 상대와 연락을 시작해보세요 : "+url)
+                        .message("매칭되었습니다! 지금 바로 상대와 연락을 시작해보세요 : " + url)
                         .phoneNumber(sender.getPhoneNumber())
                         .build();
 

--- a/src/main/java/com/now_here5/now_here/global/response/ResponseCode.java
+++ b/src/main/java/com/now_here5/now_here/global/response/ResponseCode.java
@@ -144,7 +144,8 @@ public enum ResponseCode {
     NOTIFICATION_COUNT_QUERY_FAIL(400, "L010", "알림 개수 조회에 실패했습니다."),
     SPECIAL_HEART_COUNT_QUERY_SUCCESS(200, "L011", "특별하트 개수 조회에 성공했습니다."),
     SPECIAL_HEART_COUNT_QUERY_FAIL(400, "L011", "특별하트 개수 조회에 실패했습니다."),
-
+    HEART_REMOVAL_SUCCESS(200, "L012", "보낸 하트 취소에 성공했습니다."),
+    HEART_REMOVAL_FAIL(400, "L012", "보낸 하트 취소에 실패했습니다."),
     // Interaction - 'I'nteraction
     FEEDBACK_CREATE_SUCCESS(200, "I001", "FEEDBACK 생성에 성공했습니다."),
     FEEDBACK_CREATE_FAIL(400, "I001", "FEEDBACK 생성에 실패했습니다."),


### PR DESCRIPTION
Closes #61 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/61-remove_heart -> dev `

## PR 설명
이전에 보낸 하트를 취소하는 기능을 추가.

## ✅ 완료한 기능 명세

- [x] 이슈 제목: [FEATURE] #61 '보낸 하트 취소'

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/d84c7df0-74e2-4651-ac8a-1c3b3e1f17b6)


## 고민과 해결과정
-